### PR TITLE
Fix: logger errors in reporting the number of ICA components

### DIFF
--- a/osl/preprocessing/mne_wrappers.py
+++ b/osl/preprocessing/mne_wrappers.py
@@ -372,14 +372,13 @@ def run_mne_ica_autoreject(dataset, userargs):
     eog_indices, eog_scores = dataset["ica"].find_bads_eog(
         dataset["raw"], threshold=0.35, measure="correlation"
     )
-
     dataset["ica"].exclude.extend(eog_indices)
-    logger.info("Marking {0} as EOG ICs".format(len(dataset["ica"].exclude)))
+    logger.info("Marking {0} as EOG ICs".format(len(eog_indices)))
     ecg_indices, ecg_scores = dataset["ica"].find_bads_ecg(
         dataset["raw"], threshold=ecgthreshold, method=ecgmethod
     )
     dataset["ica"].exclude.extend(ecg_indices)
-    logger.info("Marking {0} as ECG ICs".format(len(dataset["ica"].exclude)))
+    logger.info("Marking {0} as ECG ICs".format(len(ecg_indices)))
     if ("apply" not in userargs) or (userargs["apply"] is True):
         logger.info("Removing selected components from raw data")
         dataset["ica"].apply(dataset["raw"])


### PR DESCRIPTION
When logging the number of EOG and ECG ICs, `len(dataset["ica"].exclude)` is printed in both cases. However, the excluded IC indices here are cumulative. That is, when the number of ECG ICs is reported, the number of both EOG and ECG components is being printed out. This commit is to fix this error.