### PR TITLE
More consistent naming convention for source reconstruction wrappers

### DIFF
--- a/examples/lemon/source_reconstruct.py
+++ b/examples/lemon/source_reconstruct.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
         - extract_fiducials_from_fif:
             include_eeg_as_headshape: true
         - fix_headshape_fiducials: {}
-        - coregister:
+        - compute_surfaces_coregister_and_forward_model:
             include_nose: false
             use_nose: false
             use_headshape: false

--- a/examples/mrc_meguk/notts/source_reconstruct.py
+++ b/examples/mrc_meguk/notts/source_reconstruct.py
@@ -74,7 +74,7 @@ def save_polhemus_from_pos(src_dir, subject, preproc_file, smri_file, epoch_file
 config = """
     source_recon:
     - save_polhemus_from_pos: {}
-    - coregister:
+    - compute_surfaces_coregister_and_forward_model:
         include_nose: true
         use_nose: true
         use_headshape: true

--- a/examples/notts_movie_opm/prepare_parcel_ts.py
+++ b/examples/notts_movie_opm/prepare_parcel_ts.py
@@ -190,7 +190,7 @@ if False:
 if run_beamform_and_parcellate:
     config = """
         source_recon:
-        - coregister:
+        - compute_surfaces_coregister_and_forward_model:
             include_nose: false
             use_nose: false
             use_headshape: true

--- a/examples/oxford/covid/preprocess.py
+++ b/examples/oxford/covid/preprocess.py
@@ -9,7 +9,7 @@ from osl import preprocessing
 raw_file = "/ohba/pi/knobre/datasets/covid/rawbids/{0}/meg/{0}_task-restEO.fif"
 preproc_dir = "/ohba/pi/knobre/cgohil/covid/preproc"
 
-subjects = ["sub-004", "sub-005"]
+subjects = ["sub-006", "sub-007"]
 
 # Settings
 config = """

--- a/examples/oxford/covid/source_reconstruct.py
+++ b/examples/oxford/covid/source_reconstruct.py
@@ -18,15 +18,15 @@ smri_file = raw_dir + "/{0}/anat/{0}_T1w.nii"
 preproc_file = preproc_dir + "/{0}_task-restEO/{0}_task-restEO_preproc_raw.fif"
 
 # Subjects to do
-subjects = ["sub-004", "sub-005"]
+subjects = ["sub-006", "sub-007"]
 
 # Settings
 config = """
     source_recon:
     - extract_fiducials_from_fif: {}
-    - coregister:
-        include_nose: true
-        use_nose: true
+    - compute_surfaces_coregister_and_forward_model:
+        include_nose: false
+        use_nose: false
         use_headshape: true
         model: Single Layer
         recompute_surfaces: true

--- a/examples/oxford/dg_int_ext/5_source_reconstruct.py
+++ b/examples/oxford/dg_int_ext/5_source_reconstruct.py
@@ -33,9 +33,9 @@ for subject in subjects:
 config = """
     source_recon:
     - extract_fiducials_from_fif: {}
-    - coregister:
-        include_nose: true
-        use_nose: true
+    - compute_surfaces_coregister_and_forward_model:
+        include_nose: false
+        use_nose: false
         use_headshape: true
         model: Single Layer
     - beamform_and_parcellate:

--- a/examples/parallelisation/parallel_source_reconstruct.py
+++ b/examples/parallelisation/parallel_source_reconstruct.py
@@ -37,9 +37,9 @@ if __name__ == "__main__":
         source_recon:
         - extract_fiducials_from_fif: {}
         - remove_headshape_points: {}
-        - coregister:
-            include_nose: true
-            use_nose: true
+        - compute_surfaces_coregister_and_forward_model:
+            include_nose: false
+            use_nose: false
             use_headshape: true
             model: Single Layer
         - beamform_and_parcellate:

--- a/examples/parallelisation/serial_source_reconstruct.py
+++ b/examples/parallelisation/serial_source_reconstruct.py
@@ -33,9 +33,9 @@ config = """
     source_recon:
     - extract_fiducials_from_fif: {}
     - remove_headshape_points: {}
-    - coregister:
-        include_nose: true
-        use_nose: true
+    - compute_surfaces_coregister_and_forward_model:
+        include_nose: false
+        use_nose: false
         use_headshape: true
         model: Single Layer
     - beamform_and_parcellate:

--- a/examples/wakeman_henson/recon_and_parcellate.py
+++ b/examples/wakeman_henson/recon_and_parcellate.py
@@ -63,8 +63,7 @@ for sub in subjects_to_do:
 config = """
     source_recon:
     - extract_fiducials_from_fif: {}
-
-    - coregister:
+    - compute_surfaces_coregister_and_forward_model:
         include_nose: false
         use_nose: false
         use_headshape: true

--- a/osl/preprocessing/batch.py
+++ b/osl/preprocessing/batch.py
@@ -85,6 +85,8 @@ def import_data(infile, preload=True):
         raise ValueError(
             "infile must be a str. Got type(infile)={0}.".format(type(infile))
         )
+    if " " in infile:
+        raise ValueError("filename cannot contain spaces.")
 
     logger.info("IMPORTING: {0}".format(infile))
 

--- a/osl/report/src_report.py
+++ b/osl/report/src_report.py
@@ -67,7 +67,7 @@ def gen_html_data(config, src_dir, subject, reportdir, logger=None):
     data["filename"] = subject
 
     # What have we done for this subject?
-    data["coreg"] = subject_data.pop("coreg", False)
+    data["coregister"] = subject_data.pop("coregister", False)
     data["beamform"] = subject_data.pop("beamform", False)
     data["beamform_and_parcellate"] = subject_data.pop("beamform_and_parcellate", False)
     data["fix_sign_ambiguity"] = subject_data.pop("fix_sign_ambiguity", False)
@@ -75,7 +75,7 @@ def gen_html_data(config, src_dir, subject, reportdir, logger=None):
     # Save info
     if data["beamform_and_parcellate"]:
         data["n_samples"] = subject_data["n_samples"]
-    if data["coreg"]:
+    if data["coregister"]:
         data["fid_err"] = subject_data["fid_err"]
     if data["beamform_and_parcellate"]:
         data["parcellation_file"] = subject_data["parcellation_file"]
@@ -204,12 +204,12 @@ def gen_html_summary(reportdir):
     data = {}
     data["total"] = total
     data["config"] = subject_data[0]["config"]
-    data["coreg"] = subject_data[0]["coreg"]
+    data["coregister"] = subject_data[0]["coregister"]
     data["beamform"] = subject_data[0]["beamform"]
     data["beamform_and_parcellate"] = subject_data[0]["beamform_and_parcellate"]
     data["fix_sign_ambiguity"] = subject_data[0]["fix_sign_ambiguity"]
 
-    if data["coreg"]:
+    if data["coregister"]:
         subjects = np.array([d["filename"] for d in subject_data])
 
         fid_err_table = {

--- a/osl/source_recon/batch.py
+++ b/osl/source_recon/batch.py
@@ -324,13 +324,14 @@ def run_src_batch(
         "Processed {0}/{1} files successfully".format(int(np.sum(flags)), len(flags))
     )
 
-    # Generate individual subject HTML report
-    src_report.gen_html_page(reportdir)
+    if int(np.sum(flags)) > 0:
+        # Generate individual subject HTML report
+        src_report.gen_html_page(reportdir)
 
-    # Generate a summary report
-    if src_report.gen_html_summary(reportdir):
-        logger.info("******************************" + "*" * len(str(reportdir)))
-        logger.info(f"* REMEMBER TO CHECK REPORT: {reportdir} *")
-        logger.info("******************************" + "*" * len(str(reportdir)))
+        # Generate a summary report
+        if src_report.gen_html_summary(reportdir):
+            logger.info("******************************" + "*" * len(str(reportdir)))
+            logger.info(f"* REMEMBER TO CHECK REPORT: {reportdir} *")
+            logger.info("******************************" + "*" * len(str(reportdir)))
 
     return flags

--- a/osl/source_recon/batch.py
+++ b/osl/source_recon/batch.py
@@ -163,9 +163,8 @@ def run_src_chain(
 
     # Validation
     doing_coreg = (
-        any(["coregister" in method for method in config["source_recon"]]) or
         any(["compute_surfaces" in method for method in config["source_recon"]]) or
-        any(["coreg" in method for method in config["source_recon"]]) or
+        any(["coregister" in method for method in config["source_recon"]]) or
         any(["forward_model" in method for method in config["source_recon"]])
     )
     if doing_coreg and smri_file is None:
@@ -284,9 +283,8 @@ def run_src_batch(
             )
 
     doing_coreg = (
-        any(["coregister" in method for method in config["source_recon"]]) or
         any(["compute_surfaces" in method for method in config["source_recon"]]) or
-        any(["coreg" in method for method in config["source_recon"]]) or
+        any(["coregister" in method for method in config["source_recon"]]) or
         any(["forward_model" in method for method in config["source_recon"]])
     )
     if doing_coreg and smri_files is None:

--- a/osl/source_recon/rhino/coreg.py
+++ b/osl/source_recon/rhino/coreg.py
@@ -55,6 +55,8 @@ def get_coreg_filenames(subjects_dir, subject):
         A dict of files generated and used by RHINO.
     """
     basedir = op.join(subjects_dir, subject, "rhino", "coreg")
+    if " " in basedir:
+        raise ValueError("subjects_dir/src_dir cannot contain spaces.")
     os.makedirs(basedir, exist_ok=True)
 
     filenames = {

--- a/osl/source_recon/rhino/surfaces.py
+++ b/osl/source_recon/rhino/surfaces.py
@@ -45,6 +45,8 @@ def get_surfaces_filenames(subjects_dir, subject):
         - bet_outskin_*_file is the outer skin/scalp surface
     """
     basedir = op.join(subjects_dir, subject, "rhino", "surfaces")
+    if " " in basedir:
+        raise ValueError("subjects_dir/src_dir cannot contain spaces.")
     os.makedirs(basedir, exist_ok=True)
 
     filenames = {

--- a/osl/source_recon/rhino/surfaces.py
+++ b/osl/source_recon/rhino/surfaces.py
@@ -212,7 +212,7 @@ please check output of:\n fslorient -orient {}".format(
     if smri_orient != "RADIOLOGICAL" and smri_orient != "NEUROLOGICAL":
         raise ValueError(
             "Cannot determine orientation of subject brain, \
-please check output of:\n fslorient -orient {}".format(
+please check output of:\n fslorient -getorient {}".format(
                 filenames["smri_file"]
             )
         )

--- a/osl/source_recon/wrappers.py
+++ b/osl/source_recon/wrappers.py
@@ -124,7 +124,7 @@ def compute_surfaces(
     )
 
 
-def coreg(
+def coregister(
     src_dir,
     subject,
     preproc_file,
@@ -136,7 +136,7 @@ def coreg(
     allow_smri_scaling=False,
     n_init=30,
 ):
-    """Wrapper for full coregistration: compute_surfaces, coreg and forward_model.
+    """Wrapper for coregistration.
 
     Parameters
     ----------
@@ -196,7 +196,7 @@ def coreg(
     src_report.add_to_data(
         f"{src_dir}/{subject}/report_data.pkl",
         {
-            "coreg": True,
+            "coregister": True,
             "use_headshape": use_headshape,
             "use_nose": use_nose,
             "already_coregistered": already_coregistered,
@@ -253,7 +253,7 @@ def forward_model(
     )
 
 
-def coregister(
+def compute_surfaces_coregister_and_forward_model(
     src_dir,
     subject,
     preproc_file,
@@ -269,7 +269,7 @@ def coregister(
     n_init=30,
     eeg=False,
 ):
-    """Wrapper for full coregistration: compute_surfaces, coreg and forward_model.
+    """Wrapper for: compute_surfaces, coregister and forward_model.
 
     Parameters
     ----------
@@ -355,9 +355,8 @@ def coregister(
     src_report.add_to_data(
         f"{src_dir}/{subject}/report_data.pkl",
         {
-            "coregister": True,
             "compute_surfaces": True,
-            "coreg": True,
+            "coregister": True,
             "forward_model": True,
             "include_nose": include_nose,
             "use_nose": use_nose,


### PR DESCRIPTION
Closes: https://github.com/OHBA-analysis/osl/issues/148, https://github.com/OHBA-analysis/osl/issues/149.

Changes:
- More consistent naming convention for source reconstruction wrappers:
  - coregister -> compute_surfaces_coregister_and_forward_model
  - coreg -> coregister.
- Fixed typo in error message.
- Raise a value error if fif files or output file paths contain spaces.
- Only generate a source reconstruction report if we successfully processed a subject.

Note, this is an API change, will break some source reconstruction scripts.