### PR TITLE
Switch coreg html backend to panel (from threejs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ where the environment file `<os>.yml` can be:
 - `hbaws.yml` if you are using an OHBA workstation at Oxford.
 - `bmrc.yml` if you are using the BMRC at Oxford.
 
-Note, all of the above environments come with Jupyter Notebook installed. The `hbaws.yml` environment also comes with Spyder installed.
+Note, all of the above environments come with Jupyter Notebook installed. The `hbaws.yml` and `m1_mac.yml` environments also comes with Spyder installed.
 
 Deleting osl
 ------------

--- a/envs/bmrc.yml
+++ b/envs/bmrc.yml
@@ -39,9 +39,9 @@ dependencies:
   - gnutls=3.7.8=hf3e180e_0
   - hdf4=4.2.15=h501b40f_6
   - hdf5=1.14.0=nompi_hb72d44e_103
-  - icu=70.1=h27087fc_0
+  - icu=72.1=hcb278e6_0
   - idna=3.4=pyhd8ed1ab_0
-  - imageio=2.26.0=pyh24c5eb1_0
+  - imageio=2.26.1=pyh24c5eb1_0
   - jsoncpp=1.9.5=h4bd325d_1
   - keyutils=1.6.1=h166bdaf_0
   - krb5=1.20.1=h81ceb04_0
@@ -54,7 +54,7 @@ dependencies:
   - libblas=3.9.0=16_linux64_openblas
   - libcblas=3.9.0=16_linux64_openblas
   - libcurl=7.88.1=hdc1c0ab_1
-  - libdeflate=1.17=h0b41bf4_0
+  - libdeflate=1.18=h0b41bf4_0
   - libdrm=2.4.114=h166bdaf_0
   - libedit=3.1.20191231=he28a2e2_2
   - libev=4.33=h516909a_1
@@ -68,9 +68,9 @@ dependencies:
   - libidn2=2.3.4=h166bdaf_0
   - libjpeg-turbo=2.1.5.1=h0b41bf4_0
   - liblapack=3.9.0=16_linux64_openblas
-  - libllvm15=15.0.7=hadd5161_1
+  - libllvm16=16.0.0=hadd5161_1
   - libmicrohttpd=0.9.76=h87ba234_0
-  - libnetcdf=4.9.2=nompi_hf3f8848_100
+  - libnetcdf=4.9.2=nompi_hf3f8848_102
   - libnghttp2=1.52.0=h61bc06f_0
   - libnsl=2.0.0=h7f98852_0
   - libogg=1.3.4=h7f98852_1
@@ -83,21 +83,21 @@ dependencies:
   - libstdcxx-ng=12.2.0=h46fd767_19
   - libtasn1=4.19.0=h166bdaf_0
   - libtheora=1.1.1=h7f98852_1005
-  - libtiff=4.5.0=hddfeb54_5
+  - libtiff=4.5.0=ha587672_6
   - libunistring=0.9.10=h7f98852_0
   - libuuid=2.32.1=h7f98852_1000
-  - libva=2.17.0=h0b41bf4_0
+  - libva=2.18.0=h0b41bf4_0
   - libvorbis=1.3.7=h9c3ff4c_0
   - libvpx=1.11.0=h9c3ff4c_3
   - libwebp-base=1.3.0=h0b41bf4_0
   - libxcb=1.13=h7f98852_1004
-  - libxml2=2.10.3=hca2bb57_3
+  - libxml2=2.10.3=hfdac1af_6
   - libzip=1.9.2=hc929e4a_1
   - libzlib=1.2.13=h166bdaf_4
   - loguru=0.6.0=py38h578d9bd_2
   - lz4-c=1.9.4=hcb278e6_0
   - lzo=2.10=h516909a_1000
-  - mesalib=23.0.0=h3855f93_1
+  - mesalib=23.0.1=h3855f93_0
   - multidict=6.0.4=py38h1de0b5d_0
   - ncurses=6.3=h27087fc_1
   - nettle=3.8.1=hc379101_1
@@ -110,17 +110,17 @@ dependencies:
   - pillow=9.4.0=py38h961100d_2
   - pip=23.0.1=pyhd8ed1ab_0
   - platformdirs=3.1.1=pyhd8ed1ab_0
-  - pooch=1.7.0=pyhd8ed1ab_0
+  - pooch=1.7.0=pyha770c72_3
   - proj=9.1.1=h8ffa02c_2
   - pthread-stubs=0.4=h36c2ea0_1001
   - pugixml=1.11.4=h9c3ff4c_0
   - pycparser=2.21=pyhd8ed1ab_0
-  - pyopenssl=23.0.0=pyhd8ed1ab_0
+  - pyopenssl=23.1.0=pyhd8ed1ab_0
   - pysocks=1.7.1=pyha2e5f31_6
   - python=3.8.16=he550d4f_1_cpython
   - python_abi=3.8=3_cp38
   - pyvista=0.38.5=pyhd8ed1ab_0
-  - readline=8.1.2=h0f457ee_0
+  - readline=8.2=h8228510_1
   - requests=2.28.2=pyhd8ed1ab_0
   - scooby=0.7.1=pyhd8ed1ab_0
   - setuptools=67.6.0=pyhd8ed1ab_0
@@ -173,19 +173,20 @@ dependencies:
     - asttokens==2.2.1
     - babel==2.12.1
     - backcall==0.2.0
-    - beautifulsoup4==4.11.2
+    - beautifulsoup4==4.12.0
     - bleach==6.0.0
+    - bokeh==2.4.3
     - click==8.1.3
     - cloudpickle==2.2.1
-    - comm==0.1.2
+    - comm==0.1.3
     - contourpy==1.0.7
     - cycler==0.11.0
-    - dask==2023.3.1
+    - dask==2023.3.2
     - debugpy==1.6.6
     - decorator==5.1.1
     - defusedxml==0.7.1
     - dill==0.3.6
-    - distributed==2023.3.1
+    - distributed==2023.3.2
     - docutils==0.18.1
     - executing==1.2.0
     - fastjsonschema==2.16.3
@@ -193,7 +194,7 @@ dependencies:
     - fqdn==1.5.1
     - fslpy==3.11.3
     - fsspec==2023.3.0
-    - glmtools==0.2.0
+    - glmtools==0.2.1
     - h5io==0.1.7
     - h5py==3.8.0
     - heapdict==1.0.1
@@ -201,14 +202,13 @@ dependencies:
     - importlib-metadata==4.13.0
     - importlib-resources==5.12.0
     - ipycanvas==0.13.1
-    - ipydatawidgets==4.3.3
     - ipyevents==2.0.1
-    - ipykernel==6.21.3
+    - ipykernel==6.22.0
     - ipympl==0.9.3
     - ipython==8.11.0
     - ipython-genutils==0.2.0
     - ipyvtklink==0.2.2
-    - ipywidgets==8.0.4
+    - ipywidgets==8.0.5
     - isoduration==20.11.0
     - jedi==0.18.2
     - jinja2==3.1.2
@@ -216,19 +216,19 @@ dependencies:
     - jsonpointer==2.3
     - jsonschema==4.17.3
     - jupyter==1.0.0
-    - jupyter-client==8.0.3
+    - jupyter-client==8.1.0
     - jupyter-console==6.6.3
     - jupyter-core==5.3.0
     - jupyter-events==0.6.3
     - jupyter-server==2.5.0
-    - jupyter-server-proxy==3.2.2
     - jupyter-server-terminals==0.4.4
     - jupyterlab-pygments==0.2.2
-    - jupyterlab-widgets==3.0.5
+    - jupyterlab-widgets==3.0.6
     - kiwisolver==1.4.4
     - llvmlite==0.39.1
     - locket==1.0.0
     - lxml==4.9.2
+    - markdown==3.4.3
     - markupsafe==2.1.2
     - matplotlib==3.7.1
     - matplotlib-inline==0.1.6
@@ -238,7 +238,7 @@ dependencies:
     - nbclassic==0.5.3
     - nbclient==0.7.2
     - nbconvert==7.2.10
-    - nbformat==5.7.3
+    - nbformat==5.8.0
     - nest-asyncio==1.5.6
     - neurokit2==0.2.3
     - nibabel==5.0.1
@@ -251,6 +251,8 @@ dependencies:
     - opencv-python==4.7.0.72
     - pandas==1.5.3
     - pandocfilters==1.5.0
+    - panel==0.14.4
+    - param==1.13.0
     - parse==1.19.0
     - parso==0.8.3
     - partd==1.3.0
@@ -262,24 +264,24 @@ dependencies:
     - psutil==5.9.4
     - ptyprocess==0.7.0
     - pure-eval==0.2.2
+    - pyct==0.5.0
     - pygments==2.14.0
     - pyparsing==3.0.9
     - pyrsistent==0.19.3
     - python-dateutil==2.8.2
     - python-json-logger==2.0.7
-    - pythreejs==2.4.2
-    - pytz==2022.7.1
+    - pytz==2023.2
+    - pyviz-comms==2.2.1
     - pyyaml==6.0
-    - pyzmq==25.0.1
+    - pyzmq==25.0.2
     - qtconsole==5.4.1
     - qtpy==2.3.0
     - rfc3339-validator==0.1.4
     - rfc3986-validator==0.1.1
-    - sails==1.3.0
+    - sails==1.4.0
     - scikit-learn==1.2.2
     - scipy==1.10.1
     - send2trash==1.8.0
-    - simpervisor==0.4
     - six==1.16.0
     - sniffio==1.3.0
     - snowballstemmer==2.2.0
@@ -304,12 +306,11 @@ dependencies:
     - tornado==6.2
     - tqdm==4.65.0
     - traitlets==5.9.0
-    - traittypes==0.2.1
     - uri-template==1.2.0
     - wcwidth==0.2.6
     - webcolors==1.12
     - webencodings==0.5.1
     - websocket-client==1.5.1
-    - widgetsnbextension==4.0.5
+    - widgetsnbextension==4.0.6
     - zict==2.2.0
     - zipp==3.15.0

--- a/envs/hbaws.yml
+++ b/envs/hbaws.yml
@@ -39,9 +39,9 @@ dependencies:
   - gnutls=3.7.8=hf3e180e_0
   - hdf4=4.2.15=h501b40f_6
   - hdf5=1.14.0=nompi_hb72d44e_103
-  - icu=70.1=h27087fc_0
+  - icu=72.1=hcb278e6_0
   - idna=3.4=pyhd8ed1ab_0
-  - imageio=2.26.0=pyh24c5eb1_0
+  - imageio=2.26.1=pyh24c5eb1_0
   - jsoncpp=1.9.5=h4bd325d_1
   - keyutils=1.6.1=h166bdaf_0
   - krb5=1.20.1=h81ceb04_0
@@ -54,7 +54,7 @@ dependencies:
   - libblas=3.9.0=16_linux64_openblas
   - libcblas=3.9.0=16_linux64_openblas
   - libcurl=7.88.1=hdc1c0ab_1
-  - libdeflate=1.17=h0b41bf4_0
+  - libdeflate=1.18=h0b41bf4_0
   - libdrm=2.4.114=h166bdaf_0
   - libedit=3.1.20191231=he28a2e2_2
   - libev=4.33=h516909a_1
@@ -68,9 +68,9 @@ dependencies:
   - libidn2=2.3.4=h166bdaf_0
   - libjpeg-turbo=2.1.5.1=h0b41bf4_0
   - liblapack=3.9.0=16_linux64_openblas
-  - libllvm15=15.0.7=hadd5161_1
+  - libllvm16=16.0.0=hadd5161_1
   - libmicrohttpd=0.9.76=h87ba234_0
-  - libnetcdf=4.9.2=nompi_hf3f8848_100
+  - libnetcdf=4.9.2=nompi_hf3f8848_102
   - libnghttp2=1.52.0=h61bc06f_0
   - libnsl=2.0.0=h7f98852_0
   - libogg=1.3.4=h7f98852_1
@@ -83,21 +83,21 @@ dependencies:
   - libstdcxx-ng=12.2.0=h46fd767_19
   - libtasn1=4.19.0=h166bdaf_0
   - libtheora=1.1.1=h7f98852_1005
-  - libtiff=4.5.0=hddfeb54_5
+  - libtiff=4.5.0=ha587672_6
   - libunistring=0.9.10=h7f98852_0
   - libuuid=2.32.1=h7f98852_1000
-  - libva=2.17.0=h0b41bf4_0
+  - libva=2.18.0=h0b41bf4_0
   - libvorbis=1.3.7=h9c3ff4c_0
   - libvpx=1.11.0=h9c3ff4c_3
   - libwebp-base=1.3.0=h0b41bf4_0
   - libxcb=1.13=h7f98852_1004
-  - libxml2=2.10.3=hca2bb57_3
+  - libxml2=2.10.3=hfdac1af_6
   - libzip=1.9.2=hc929e4a_1
   - libzlib=1.2.13=h166bdaf_4
   - loguru=0.6.0=py38h578d9bd_2
   - lz4-c=1.9.4=hcb278e6_0
   - lzo=2.10=h516909a_1000
-  - mesalib=23.0.0=h3855f93_1
+  - mesalib=23.0.1=h3855f93_0
   - multidict=6.0.4=py38h1de0b5d_0
   - ncurses=6.3=h27087fc_1
   - nettle=3.8.1=hc379101_1
@@ -110,17 +110,17 @@ dependencies:
   - pillow=9.4.0=py38h961100d_2
   - pip=23.0.1=pyhd8ed1ab_0
   - platformdirs=3.1.1=pyhd8ed1ab_0
-  - pooch=1.7.0=pyhd8ed1ab_0
+  - pooch=1.7.0=pyha770c72_3
   - proj=9.1.1=h8ffa02c_2
   - pthread-stubs=0.4=h36c2ea0_1001
   - pugixml=1.11.4=h9c3ff4c_0
   - pycparser=2.21=pyhd8ed1ab_0
-  - pyopenssl=23.0.0=pyhd8ed1ab_0
+  - pyopenssl=23.1.0=pyhd8ed1ab_0
   - pysocks=1.7.1=pyha2e5f31_6
   - python=3.8.16=he550d4f_1_cpython
   - python_abi=3.8=3_cp38
   - pyvista=0.38.5=pyhd8ed1ab_0
-  - readline=8.1.2=h0f457ee_0
+  - readline=8.2=h8228510_1
   - requests=2.28.2=pyhd8ed1ab_0
   - scooby=0.7.1=pyhd8ed1ab_0
   - setuptools=67.6.0=pyhd8ed1ab_0
@@ -176,24 +176,25 @@ dependencies:
     - autopep8==1.5.7
     - babel==2.12.1
     - backcall==0.2.0
-    - beautifulsoup4==4.11.2
+    - beautifulsoup4==4.12.0
     - binaryornot==0.4.4
     - black==23.1.0
     - bleach==6.0.0
+    - bokeh==2.4.3
     - chardet==5.1.0
     - click==8.1.3
     - cloudpickle==2.2.1
-    - comm==0.1.2
+    - comm==0.1.3
     - contourpy==1.0.7
     - cookiecutter==2.1.1
     - cycler==0.11.0
-    - dask==2023.3.1
+    - dask==2023.3.2
     - debugpy==1.6.6
     - decorator==5.1.1
     - defusedxml==0.7.1
     - diff-match-patch==20200713
     - dill==0.3.6
-    - distributed==2023.3.1
+    - distributed==2023.3.2
     - docutils==0.18.1
     - executing==1.2.0
     - fastjsonschema==2.16.3
@@ -201,7 +202,7 @@ dependencies:
     - fonttools==4.39.2
     - fslpy==3.11.3
     - fsspec==2023.3.0
-    - glmtools==0.2.0
+    - glmtools==0.2.1
     - h5io==0.1.7
     - h5py==3.8.0
     - heapdict==1.0.1
@@ -211,14 +212,13 @@ dependencies:
     - inflection==0.5.1
     - intervaltree==3.1.0
     - ipycanvas==0.13.1
-    - ipydatawidgets==4.3.3
     - ipyevents==2.0.1
-    - ipykernel==6.21.3
+    - ipykernel==6.22.0
     - ipympl==0.9.3
     - ipython==8.11.0
     - ipython-genutils==0.2.0
     - ipyvtklink==0.2.2
-    - ipywidgets==8.0.4
+    - ipywidgets==8.0.5
     - isort==5.12.0
     - jaraco-classes==3.2.3
     - jedi==0.18.2
@@ -233,13 +233,14 @@ dependencies:
     - jupyter-core==5.3.0
     - jupyter-server==1.23.6
     - jupyterlab-pygments==0.2.2
-    - jupyterlab-widgets==3.0.5
+    - jupyterlab-widgets==3.0.6
     - keyring==23.13.1
     - kiwisolver==1.4.4
     - lazy-object-proxy==1.9.0
     - llvmlite==0.39.1
     - locket==1.0.0
     - lxml==4.9.2
+    - markdown==3.4.3
     - markupsafe==2.1.2
     - matplotlib==3.7.1
     - matplotlib-inline==0.1.6
@@ -252,7 +253,7 @@ dependencies:
     - nbclassic==0.5.3
     - nbclient==0.7.2
     - nbconvert==7.2.10
-    - nbformat==5.7.3
+    - nbformat==5.8.0
     - nest-asyncio==1.5.6
     - neurokit2==0.2.3
     - nibabel==5.0.1
@@ -265,6 +266,8 @@ dependencies:
     - opencv-python==4.7.0.72
     - pandas==1.5.3
     - pandocfilters==1.5.0
+    - panel==0.14.4
+    - param==1.13.0
     - parse==1.19.0
     - parso==0.8.3
     - partd==1.3.0
@@ -279,6 +282,7 @@ dependencies:
     - ptyprocess==0.7.0
     - pure-eval==0.2.2
     - pycodestyle==2.7.0
+    - pyct==0.5.0
     - pydocstyle==6.3.0
     - pyflakes==2.3.1
     - pygments==2.14.0
@@ -294,12 +298,12 @@ dependencies:
     - python-lsp-jsonrpc==1.0.0
     - python-lsp-server==1.2.4
     - python-slugify==8.0.1
-    - pythreejs==2.4.2
     - pytoolconfig==1.2.5
-    - pytz==2022.7.1
+    - pytz==2023.2
+    - pyviz-comms==2.2.1
     - pyxdg==0.28
     - pyyaml==6.0
-    - pyzmq==25.0.1
+    - pyzmq==25.0.2
     - qdarkstyle==3.0.2
     - qstylizer==0.2.2
     - qtawesome==1.2.3
@@ -307,7 +311,7 @@ dependencies:
     - qtpy==2.3.0
     - rope==1.7.0
     - rtree==1.0.1
-    - sails==1.3.0
+    - sails==1.4.0
     - scikit-learn==1.2.2
     - scipy==1.10.1
     - secretstorage==3.3.3
@@ -343,13 +347,12 @@ dependencies:
     - tornado==6.2
     - tqdm==4.65.0
     - traitlets==5.9.0
-    - traittypes==0.2.1
     - ujson==5.7.0
-    - watchdog==2.3.1
+    - watchdog==3.0.0
     - wcwidth==0.2.6
     - webencodings==0.5.1
     - websocket-client==1.5.1
-    - widgetsnbextension==4.0.5
+    - widgetsnbextension==4.0.6
     - wrapt==1.12.1
     - wurlitzer==3.0.3
     - yapf==0.32.0

--- a/envs/m1_mac.yml
+++ b/envs/m1_mac.yml
@@ -3,39 +3,97 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - brotlipy=0.7.0=py310h8e9501a_1005
+  - alabaster=0.7.13=pyhd8ed1ab_0
+  - applaunchservices=0.3.0=pyhd8ed1ab_2
+  - appnope=0.1.3=pyhd8ed1ab_0
+  - arrow=1.2.3=pyhd8ed1ab_0
+  - astroid=2.15.0=py38h10201cd_0
+  - asttokens=2.2.1=pyhd8ed1ab_0
+  - atomicwrites=1.4.1=pyhd8ed1ab_0
+  - attrs=22.2.0=pyh71513ae_0
+  - autopep8=1.6.0=pyhd8ed1ab_1
+  - babel=2.12.1=pyhd8ed1ab_1
+  - backcall=0.2.0=pyh9f0ad1d_0
+  - backports=1.0=pyhd8ed1ab_3
+  - backports.functools_lru_cache=1.6.4=pyhd8ed1ab_0
+  - beautifulsoup4=4.12.0=pyha770c72_0
+  - binaryornot=0.4.4=py_1
+  - black=23.1.0=py38h10201cd_0
+  - bleach=6.0.0=pyhd8ed1ab_0
+  - brotlipy=0.7.0=py38hb991d35_1005
   - bzip2=1.0.8=h3422bc3_4
   - c-ares=1.18.1=h3422bc3_0
   - ca-certificates=2022.12.7=h4653dfc_0
   - certifi=2022.12.7=pyhd8ed1ab_0
-  - cffi=1.15.1=py310h2399d43_3
+  - cffi=1.15.1=py38ha45ccd6_3
+  - chardet=5.1.0=py38h10201cd_0
   - charset-normalizer=2.1.1=pyhd8ed1ab_0
-  - cryptography=39.0.2=py310hfc83b78_0
-  - curl=7.88.1=h9049daf_1
+  - click=8.1.3=unix_pyhd8ed1ab_2
+  - cloudpickle=2.2.1=pyhd8ed1ab_0
+  - colorama=0.4.6=pyhd8ed1ab_0
+  - comm=0.1.3=pyhd8ed1ab_0
+  - cookiecutter=2.1.1=pyh6c4a22f_0
+  - cryptography=39.0.2=py38h23f6d3d_0
+  - curl=7.86.0=h1c293e1_1
+  - debugpy=1.6.6=py38h2b1e499_0
+  - decorator=5.1.1=pyhd8ed1ab_0
+  - defusedxml=0.7.1=pyhd8ed1ab_0
+  - diff-match-patch=20200713=pyh9f0ad1d_0
+  - dill=0.3.6=pyhd8ed1ab_1
+  - docstring-to-markdown=0.12=pyhd8ed1ab_0
   - double-conversion=3.1.7=hbdafb3b_0
   - eigen=3.4.0=hc021e02_0
+  - entrypoints=0.4=pyhd8ed1ab_0
+  - executing=1.2.0=pyhd8ed1ab_0
   - expat=2.5.0=hb7217d7_0
   - ffmpeg=4.3.2=h38cfed3_3
+  - flake8=6.0.0=pyhd8ed1ab_0
   - freetype=2.12.1=hd633e50_1
   - gettext=0.21.1=h0186832_0
+  - giflib=5.2.1=h1a8c8d9_3
   - gl2ps=1.4.2=h17b34a0_0
   - glew=2.1.0=h9f76cd9_2
+  - glib=2.74.1=hb5ab8b9_1
+  - glib-tools=2.74.1=hb5ab8b9_1
   - gmp=6.2.1=h9f76cd9_0
   - gnutls=3.6.13=h706517b_1
+  - gst-plugins-base=1.21.3=h8b7775e_1
+  - gstreamer=1.21.3=hcb7b3dd_1
   - hdf4=4.2.15=h1a38d6a_5
   - hdf5=1.12.1=nompi_hd9dbc9e_104
   - icu=70.1=h6b3803e_0
   - idna=3.4=pyhd8ed1ab_0
-  - imageio=2.26.0=pyh24c5eb1_0
+  - imageio=2.26.1=pyh24c5eb1_0
+  - imagesize=1.4.1=pyhd8ed1ab_0
+  - importlib_metadata=6.1.0=hd8ed1ab_0
+  - importlib_resources=5.12.0=pyhd8ed1ab_0
+  - inflection=0.5.1=pyh9f0ad1d_0
+  - intervaltree=3.0.2=py_0
+  - ipykernel=6.22.0=pyh736e0ef_0
+  - ipython=8.11.0=pyhd1c38e8_0
+  - ipython_genutils=0.2.0=py_1
+  - isort=5.12.0=pyhd8ed1ab_1
+  - jaraco.classes=3.2.3=pyhd8ed1ab_0
+  - jedi=0.18.2=pyhd8ed1ab_0
+  - jellyfish=0.9.0=py38hb991d35_2
+  - jinja2=3.1.2=pyhd8ed1ab_1
+  - jinja2-time=0.2.0=pyhd8ed1ab_3
   - jpeg=9e=h1a8c8d9_3
   - jsoncpp=1.9.4=hc021e02_3
-  - krb5=1.20.1=h69eda48_0
+  - jsonschema=4.17.3=pyhd8ed1ab_0
+  - jupyter_core=5.3.0=py38h10201cd_0
+  - jupyterlab_pygments=0.2.2=pyhd8ed1ab_0
+  - keyring=23.13.1=py38h10201cd_0
+  - krb5=1.19.3=he492e65_0
   - lame=3.100=h1a8c8d9_1003
+  - lazy-object-proxy=1.9.0=py38hb991d35_0
   - lcms2=2.14=h8193b64_0
   - lerc=4.0.0=h9a09cb3_0
   - libblas=3.9.0=16_osxarm64_openblas
   - libcblas=3.9.0=16_osxarm64_openblas
-  - libcurl=7.88.1=h9049daf_1
+  - libclang=15.0.7=default_h9e54d93_1
+  - libclang13=15.0.7=default_h7d574e7_1
+  - libcurl=7.86.0=h1c293e1_1
   - libcxx=15.0.7=h75e25f2_0
   - libdeflate=1.14=h1a8c8d9_0
   - libedit=3.1.20191231=hc8eb9b7_2
@@ -43,143 +101,222 @@ dependencies:
   - libffi=3.4.2=h3422bc3_5
   - libgfortran=5.0.0=12_2_0_hd922786_31
   - libgfortran5=12.2.0=h0eea778_31
+  - libglib=2.74.1=h4646484_1
   - libiconv=1.17=he4db4b2_0
   - liblapack=3.9.0=16_osxarm64_openblas
+  - libllvm15=15.0.7=h62b9111_1
   - libnetcdf=4.8.1=nompi_h96a3436_102
   - libnghttp2=1.52.0=hae82a92_0
   - libogg=1.3.4=h27ca646_1
   - libopenblas=0.3.21=openmp_hc731615_3
+  - libopus=1.3.1=h27ca646_1
   - libpng=1.6.39=h76d750c_0
+  - libpq=15.1=h998ac43_1
+  - libsodium=1.0.18=h27ca646_1
+  - libspatialindex=1.9.3=hbdafb3b_4
   - libsqlite=3.40.0=h76d750c_0
   - libssh2=1.10.0=h7a5bd25_3
   - libtheora=1.1.1=h3422bc3_1005
   - libtiff=4.4.0=heb92581_5
   - libvorbis=1.3.7=h9f76cd9_0
-  - libwebp-base=1.3.0=h1a8c8d9_0
+  - libwebp=1.2.4=h328b37c_0
+  - libwebp-base=1.2.4=h1a8c8d9_0
   - libxcb=1.13=h9b22ae9_1004
-  - libxml2=2.10.3=h87b0503_3
+  - libxml2=2.10.3=h67585b2_4
   - libzip=1.9.2=h76ab92c_1
   - libzlib=1.2.13=h03a7124_4
   - llvm-openmp=16.0.0=h7cfbb63_0
-  - loguru=0.6.0=py310hbe9552e_2
+  - loguru=0.6.0=py38h10201cd_2
   - lz4-c=1.9.3=hbdafb3b_1
+  - markupsafe=2.1.2=py38hb991d35_0
+  - matplotlib-inline=0.1.6=pyhd8ed1ab_0
+  - mccabe=0.7.0=pyhd8ed1ab_0
+  - mistune=2.0.5=pyhd8ed1ab_0
+  - more-itertools=9.1.0=pyhd8ed1ab_0
+  - mypy_extensions=1.0.0=pyha770c72_0
+  - mysql-common=8.0.32=h518ea0a_1
+  - mysql-libs=8.0.32=hcb599eb_1
+  - nbclient=0.7.2=pyhd8ed1ab_0
+  - nbconvert=7.2.9=pyhd8ed1ab_0
+  - nbconvert-core=7.2.9=pyhd8ed1ab_0
+  - nbconvert-pandoc=7.2.9=pyhd8ed1ab_0
+  - nbformat=5.8.0=pyhd8ed1ab_0
   - ncurses=6.3=h07bb92c_1
+  - nest-asyncio=1.5.6=pyhd8ed1ab_0
   - nettle=3.6=hc6a1b29_0
+  - nspr=4.35=hb7217d7_0
+  - nss=3.89=h789eff7_0
+  - numpydoc=1.5.0=pyhd8ed1ab_0
   - openh264=2.1.1=habe5f53_0
   - openjpeg=2.5.0=h5d4e404_1
   - openssl=3.1.0=h03a7124_0
   - packaging=23.0=pyhd8ed1ab_0
-  - pillow=9.2.0=py310h9337a76_3
+  - pandoc=2.19.2=hce30654_2
+  - pandocfilters=1.5.0=pyhd8ed1ab_0
+  - parso=0.8.3=pyhd8ed1ab_0
+  - pathspec=0.11.1=pyhd8ed1ab_0
+  - pcre2=10.40=hb34f9b4_0
+  - pexpect=4.8.0=pyh1a96a4e_2
+  - pickleshare=0.7.5=py_1003
+  - pillow=9.2.0=py38hf86a106_3
   - pip=23.0.1=pyhd8ed1ab_0
+  - pkgutil-resolve-name=1.3.10=pyhd8ed1ab_0
   - platformdirs=3.1.1=pyhd8ed1ab_0
-  - pooch=1.7.0=pyhd8ed1ab_0
+  - pluggy=1.0.0=pyhd8ed1ab_5
+  - ply=3.11=py_1
+  - pooch=1.7.0=pyha770c72_3
   - proj=8.2.0=h2d984c1_0
+  - prompt-toolkit=3.0.38=pyha770c72_0
+  - prompt_toolkit=3.0.38=hd8ed1ab_0
+  - psutil=5.9.4=py38hb991d35_0
   - pthread-stubs=0.4=h27ca646_1001
+  - ptyprocess=0.7.0=pyhd3deb0d_0
   - pugixml=1.11.4=hbdafb3b_0
+  - pure_eval=0.2.2=pyhd8ed1ab_0
+  - pycodestyle=2.10.0=pyhd8ed1ab_0
   - pycparser=2.21=pyhd8ed1ab_0
-  - pyopenssl=23.0.0=pyhd8ed1ab_0
+  - pydocstyle=6.2.3=pyhd8ed1ab_0
+  - pyflakes=3.0.1=pyhd8ed1ab_0
+  - pygments=2.14.0=pyhd8ed1ab_0
+  - pylint=2.17.1=pyhd8ed1ab_0
+  - pylint-venv=3.0.1=pyhd8ed1ab_0
+  - pyls-spyder=0.4.0=pyhd8ed1ab_0
+  - pyobjc-core=9.0=py38h3eb5a62_1
+  - pyobjc-framework-cocoa=9.0=py38hb094c41_0
+  - pyobjc-framework-coreservices=9.0=py38hb991d35_0
+  - pyobjc-framework-fsevents=9.0=py38hca03da5_0
+  - pyopenssl=23.1.0=pyhd8ed1ab_0
+  - pyqt=5.15.7=py38hd4e55b5_3
+  - pyqt5-sip=12.11.0=py38h2b1e499_3
+  - pyqtwebengine=5.15.7=py38h2ca97f4_3
+  - pyrsistent=0.19.3=py38hb991d35_0
   - pysocks=1.7.1=pyha2e5f31_6
-  - python=3.10.9=h3ba56d0_0_cpython
-  - python_abi=3.10=3_cp310
+  - python=3.8.16=h3ba56d0_1_cpython
+  - python-dateutil=2.8.2=pyhd8ed1ab_0
+  - python-fastjsonschema=2.16.3=pyhd8ed1ab_0
+  - python-lsp-black=1.2.1=pyhd8ed1ab_0
+  - python-lsp-jsonrpc=1.0.0=pyhd8ed1ab_0
+  - python-lsp-server=1.7.1=hd8ed1ab_0
+  - python-lsp-server-base=1.7.1=pyhd8ed1ab_0
+  - python-slugify=8.0.1=pyhd8ed1ab_0
+  - python.app=1.4=py38h971d552_1
+  - python_abi=3.8=3_cp38
+  - pytoolconfig=1.2.5=pyhd8ed1ab_0
+  - pytz=2023.2=pyhd8ed1ab_0
   - pyvista=0.38.5=pyhd8ed1ab_0
-  - readline=8.1.2=h46ed386_0
+  - pyyaml=6.0=py38hb991d35_5
+  - pyzmq=25.0.2=py38hb72be9f_0
+  - qdarkstyle=3.0.3=pyhd8ed1ab_0
+  - qstylizer=0.2.2=pyhd8ed1ab_0
+  - qt-main=5.15.6=h160f5ef_4
+  - qt-webengine=5.15.4=h3a00a3b_3
+  - qtawesome=1.2.3=pyhd8ed1ab_0
+  - qtconsole=5.4.1=pyhd8ed1ab_0
+  - qtconsole-base=5.4.1=pyha770c72_0
+  - qtpy=2.3.0=pyhd8ed1ab_0
+  - readline=8.2=h92ec313_1
   - requests=2.28.2=pyhd8ed1ab_0
+  - rope=1.7.0=pyhd8ed1ab_0
+  - rtree=1.0.1=py38hb34dff0_1
   - scooby=0.7.1=pyhd8ed1ab_0
   - setuptools=67.6.0=pyhd8ed1ab_0
+  - sip=6.7.7=py38h2b1e499_0
+  - six=1.16.0=pyh6c4a22f_0
+  - snowballstemmer=2.2.0=pyhd8ed1ab_0
+  - sortedcontainers=2.4.0=pyhd8ed1ab_0
+  - soupsieve=2.3.2.post1=pyhd8ed1ab_0
+  - sphinx=6.1.3=pyhd8ed1ab_0
+  - sphinxcontrib-applehelp=1.0.4=pyhd8ed1ab_0
+  - sphinxcontrib-devhelp=1.0.2=py_0
+  - sphinxcontrib-htmlhelp=2.0.1=pyhd8ed1ab_0
+  - sphinxcontrib-jsmath=1.0.1=py_0
+  - sphinxcontrib-qthelp=1.0.3=py_0
+  - sphinxcontrib-serializinghtml=1.1.5=pyhd8ed1ab_2
+  - spyder=5.4.2=py38h10201cd_0
+  - spyder-kernels=2.4.2=unix_pyhd8ed1ab_0
   - sqlite=3.40.0=h2229b38_0
-  - tbb=2020.2=h260d524_4
-  - tbb-devel=2020.2=h260d524_4
+  - stack_data=0.6.2=pyhd8ed1ab_0
+  - tbb=2021.8.0=hffc8910_0
+  - tbb-devel=2021.8.0=h4f9cb39_0
+  - text-unidecode=1.3=py_0
+  - textdistance=4.5.0=pyhd8ed1ab_0
+  - three-merge=0.1.1=pyh9f0ad1d_0
+  - tinycss2=1.2.1=pyhd8ed1ab_0
   - tk=8.6.12=he1e0b03_0
+  - toml=0.10.2=pyhd8ed1ab_0
+  - tomli=2.0.1=pyhd8ed1ab_0
+  - tomlkit=0.11.6=pyha770c72_0
+  - tornado=6.2=py38hb991d35_1
+  - traitlets=5.9.0=pyhd8ed1ab_0
+  - typing=3.10.0.0=pyhd8ed1ab_0
   - typing-extensions=4.5.0=hd8ed1ab_0
   - typing_extensions=4.5.0=pyha770c72_0
-  - tzdata=2022g=h191b570_0
+  - ujson=5.7.0=py38h2b1e499_0
+  - unidecode=1.3.6=pyhd8ed1ab_0
   - urllib3=1.26.15=pyhd8ed1ab_0
   - utfcpp=3.2.3=hce30654_0
-  - vtk=9.1.0=no_osmesa_py310h9191020_102
+  - vtk=9.1.0=no_osmesa_py38hf0a37f6_102
+  - watchdog=3.0.0=py38hb991d35_0
+  - wcwidth=0.2.6=pyhd8ed1ab_0
+  - webencodings=0.5.1=py_1
+  - whatthepatch=1.0.4=pyhd8ed1ab_0
   - wheel=0.40.0=pyhd8ed1ab_0
+  - wrapt=1.15.0=py38hb991d35_0
+  - wurlitzer=3.0.3=pyhd8ed1ab_0
   - x264=1!161.3030=h3422bc3_1
   - xorg-libxau=1.0.9=h27ca646_0
   - xorg-libxdmcp=1.1.3=h27ca646_0
   - xz=5.2.6=h57fd34a_0
+  - yaml=0.2.5=h3422bc3_2
+  - yapf=0.32.0=pyhd8ed1ab_0
+  - zeromq=4.3.4=hbdafb3b_1
+  - zipp=3.15.0=pyhd8ed1ab_0
   - zlib=1.2.13=h03a7124_4
   - zstd=1.5.2=hf913c23_6
   - pip:
-    - alabaster==0.7.13
     - anamnesis==1.0.4
     - anyio==3.6.2
-    - appnope==0.1.3
     - argon2-cffi==21.3.0
     - argon2-cffi-bindings==21.2.0
-    - arrow==1.2.3
-    - asttokens==2.2.1
-    - attrs==22.2.0
-    - babel==2.12.1
-    - backcall==0.2.0
-    - beautifulsoup4==4.11.2
-    - bleach==6.0.0
-    - click==8.1.3
-    - cloudpickle==2.2.1
-    - comm==0.1.2
+    - bokeh==2.4.3
     - contourpy==1.0.7
     - cycler==0.11.0
-    - dask==2023.3.1
-    - debugpy==1.6.6
-    - decorator==5.1.1
-    - defusedxml==0.7.1
-    - dill==0.3.6
-    - distributed==2023.3.1
+    - dask==2023.3.2
+    - distributed==2023.3.2
     - docutils==0.18.1
-    - executing==1.2.0
-    - fastjsonschema==2.16.3
     - fonttools==4.39.2
     - fqdn==1.5.1
     - fslpy==3.11.3
     - fsspec==2023.3.0
-    - glmtools==0.2.0
+    - glmtools==0.2.1
     - h5io==0.1.7
     - h5py==3.8.0
     - heapdict==1.0.1
-    - imagesize==1.4.1
     - importlib-metadata==4.13.0
     - ipycanvas==0.13.1
-    - ipydatawidgets==4.3.3
     - ipyevents==2.0.1
-    - ipykernel==6.21.3
     - ipympl==0.9.3
-    - ipython==8.11.0
-    - ipython-genutils==0.2.0
     - ipyvtklink==0.2.2
-    - ipywidgets==8.0.4
+    - ipywidgets==8.0.5
     - isoduration==20.11.0
-    - jedi==0.18.2
-    - jinja2==3.1.2
     - joblib==1.2.0
     - jsonpointer==2.3
-    - jsonschema==4.17.3
     - jupyter==1.0.0
-    - jupyter-client==8.0.3
+    - jupyter-client==8.1.0
     - jupyter-console==6.6.3
-    - jupyter-core==5.3.0
     - jupyter-events==0.6.3
     - jupyter-server==2.5.0
     - jupyter-server-terminals==0.4.4
-    - jupyterlab-pygments==0.2.2
-    - jupyterlab-widgets==3.0.5
+    - jupyterlab-widgets==3.0.6
     - kiwisolver==1.4.4
     - llvmlite==0.39.1
     - locket==1.0.0
     - lxml==4.9.2
-    - markupsafe==2.1.2
+    - markdown==3.4.3
     - matplotlib==3.7.1
-    - matplotlib-inline==0.1.6
-    - mistune==2.0.5
     - mne==1.3.1
     - msgpack==1.0.5
     - nbclassic==0.5.3
-    - nbclient==0.7.2
-    - nbconvert==7.2.10
-    - nbformat==5.7.3
-    - nest-asyncio==1.5.6
     - neurokit2==0.2.3
     - nibabel==5.0.1
     - nilearn==0.10.0
@@ -187,67 +324,34 @@ dependencies:
     - notebook-shim==0.2.2
     - numba==0.56.4
     - numpy==1.23.5
-    - numpydoc==1.5.0
     - opencv-python==4.7.0.72
     - pandas==1.5.3
-    - pandocfilters==1.5.0
+    - panel==0.14.4
+    - param==1.13.0
     - parse==1.19.0
-    - parso==0.8.3
     - partd==1.3.0
-    - pexpect==4.8.0
-    - pickleshare==0.7.5
     - prometheus-client==0.16.0
-    - prompt-toolkit==3.0.38
-    - psutil==5.9.4
-    - ptyprocess==0.7.0
-    - pure-eval==0.2.2
-    - pygments==2.14.0
+    - pyct==0.5.0
     - pyparsing==3.0.9
-    - pyrsistent==0.19.3
-    - python-dateutil==2.8.2
     - python-json-logger==2.0.7
-    - pythreejs==2.4.2
-    - pytz==2022.7.1
-    - pyyaml==6.0
-    - pyzmq==25.0.1
-    - qtconsole==5.4.1
-    - qtpy==2.3.0
+    - pyviz-comms==2.2.1
     - rfc3339-validator==0.1.4
     - rfc3986-validator==0.1.1
-    - sails==1.3.0
+    - sails==1.4.0
     - scikit-learn==1.2.2
     - scipy==1.10.1
     - send2trash==1.8.0
-    - six==1.16.0
     - sniffio==1.3.0
-    - snowballstemmer==2.2.0
-    - sortedcontainers==2.4.0
-    - soupsieve==2.4
-    - sphinx==6.1.3
     - sphinx-rtd-theme==1.2.0
-    - sphinxcontrib-applehelp==1.0.4
-    - sphinxcontrib-devhelp==1.0.2
-    - sphinxcontrib-htmlhelp==2.0.1
     - sphinxcontrib-jquery==4.1
-    - sphinxcontrib-jsmath==1.0.1
-    - sphinxcontrib-qthelp==1.0.3
-    - sphinxcontrib-serializinghtml==1.1.5
-    - stack-data==0.6.2
     - tabulate==0.9.0
     - tblib==1.7.0
     - terminado==0.17.1
     - threadpoolctl==3.1.0
-    - tinycss2==1.2.1
     - toolz==0.12.0
-    - tornado==6.2
     - tqdm==4.65.0
-    - traitlets==5.9.0
-    - traittypes==0.2.1
     - uri-template==1.2.0
-    - wcwidth==0.2.6
     - webcolors==1.12
-    - webencodings==0.5.1
     - websocket-client==1.5.1
-    - widgetsnbextension==4.0.5
+    - widgetsnbextension==4.0.6
     - zict==2.2.0
-    - zipp==3.15.0

--- a/envs/osl-workshop-23.yml
+++ b/envs/osl-workshop-23.yml
@@ -2,44 +2,44 @@ name: osl-ws
 channels:
 - conda-forge
 dependencies:
-- python=3.8
+- python=3.8.16
 - pip=23.0.1
 - vtk=9.1.0=*osmesa*
 - pyvista=0.38.5
 - pip:
   - jupyter==1.0.0
   - ipympl==0.9.3
-  - ipywidgets==8.0.4
+  - ipywidgets==8.0.5
   - ipyevents==2.0.1
   - ipyvtklink==0.2.2
-  - jupyter-client==6.1.12
+  - jupyter-client==8.1.0
   - numpy==1.23.5
   - scipy==1.10.1
   - matplotlib==3.7.1
   - mne==1.3.1
   - scikit-learn==1.2.2
   - fslpy==3.11.3
-  - sails==1.3.0
+  - sails==1.4.0
   - tabulate==0.9.0
   - pyyaml==6.0
   - neurokit2==0.2.3
   - jinja2==3.1.2
-  - glmtools==0.2.0
+  - glmtools==0.2.1
   - numba==0.56.4
   - nilearn==0.10.0
-  - dask==2023.3.1
-  - distributed==2023.3.1
+  - dask==2023.3.2
+  - distributed==2023.3.2
   - parse==1.19.0
   - opencv-python==4.7.0.72
-  - pythreejs==2.4.2
   - h5io==0.1.7
   - mat73==0.60
   - nibabel==5.0.1
   - pandas==1.5.3
+  - panel==0.14.4
   - pre-commit==3.2.0
   - pqdm==0.2.0
   - seaborn==0.12.2
   - tensorflow_probability==0.17.0
   - tqdm==4.65.0
-  - osl==0.3.0
+  - osl==0.2.0
   - osl-dynamics==1.2.0

--- a/osl/source_recon/rhino/utils.py
+++ b/osl/source_recon/rhino/utils.py
@@ -1017,7 +1017,7 @@ def save_or_show_renderer(renderer, filename):
 
         log_or_print(f"saving {filename}")
         if ext == ".html":
-            renderer.figure.plotter.export_html(filename)
+            renderer.figure.plotter.export_html(filename, backend="panel")
         elif ext in allowed_extensions:
             renderer.figure.plotter.save_graphic(filename)
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ README = (HERE / "README.md").read_text()
 reqs = ['numpy', 'scipy', 'matplotlib', 'mne>=1.0.0', 'scikit-learn', 'fslpy',
         'sails', 'tabulate', 'pyyaml>=5.1', 'neurokit2', 'jinja2',
         'glmtools', 'numba', 'nilearn', 'dask', 'distributed', 'parse',
-        'opencv-python', 'pythreejs', 'h5io']
+        'opencv-python', 'panel', 'h5io']
 doc_reqs = ['sphinx==4.0.2', 'numpydoc', 'sphinx_gallery', 'pydata-sphinx-theme']
 dev_reqs = ['setuptools>=41.0.1', 'pytest', 'pytest-cov', 'coverage', 'flake8']
 


### PR DESCRIPTION
Closes https://github.com/OHBA-analysis/osl/issues/146.

Changes:
- For some reason the `coreg.html` plots of the coregistration have broken, previously generated `coreg.html` files and new ones no longer open in any web browser. This might be due to updated to the web browsers. Switching the backend from `threejs` to `panel` has resolved this.
- `threejs` was removed from the dependencies and `panel` was added.