### PR TITLE
Parcellation Updates

### DIFF
--- a/osl/source_recon/beamforming.py
+++ b/osl/source_recon/beamforming.py
@@ -200,7 +200,7 @@ def make_lcmv(
     return filters
 
 
-def apply_lcmv(data, filters, reject_by_annotation=None):
+def apply_lcmv(data, filters, reject_by_annotation="omit"):
     """Apply a LCMV filter to an MNE Raw or Epochs object."""
     if isinstance(data, mne.io.Raw):
         return apply_lcmv_raw(data, filters, reject_by_annotation)
@@ -208,7 +208,7 @@ def apply_lcmv(data, filters, reject_by_annotation=None):
         return mne.beamformer.apply_lcmv_epochs(data, filters)
 
 
-def apply_lcmv_raw(raw, filters, reject_by_annotation=None):
+def apply_lcmv_raw(raw, filters, reject_by_annotation="omit"):
     """Modified version of mne.beamformer.apply_lcmv_raw."""
 
     _check_reference(raw)

--- a/osl/source_recon/parcellation/parcellation.py
+++ b/osl/source_recon/parcellation/parcellation.py
@@ -883,6 +883,8 @@ def convert2mne_raw(parc_data, raw, parcel_names=None, extra_chans="stim"):
     parc_raw.set_annotations(raw._annotations)
 
     # Add extra channels
+    if "stim" not in raw:
+        log_or_print("No stim channel to add to parc-raw.fif", warning=True)
     for extra_chan in extra_chans:
         if extra_chan in raw:
             chan_raw = raw.copy().pick(extra_chan)

--- a/osl/source_recon/wrappers.py
+++ b/osl/source_recon/wrappers.py
@@ -26,6 +26,7 @@ from . import rhino, beamforming, parcellation, sign_flipping
 from ..report import src_report
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -397,8 +398,6 @@ def beamform(
     freq_range,
     chantypes,
     rank,
-    spatial_resolution=None,
-    reference_brain="mni",
 ):
     """Wrapper function for beamforming.
 
@@ -421,20 +420,6 @@ def beamform(
         Channel types to use in beamforming.
     rank : dict
         Keys should be the channel types and the value should be the rank to use.
-    spatial_resolution : int
-        Resolution for beamforming to use for the reference brain in mm
-        (must be an integer, or will be cast to nearest int)
-        If None, then the gridstep used in coreg_filenames['forward_model_file']
-        is used.
-    reference_brain : string
-        'mni' indicates that the reference_brain is the stdbrain in MNI space
-        'mri' indicates that the reference_brain is the subject's sMRI in
-            the scaled native/mri space. "
-        'unscaled_mri' indicates that the reference_brain is the subject's sMRI in
-            unscaled native/mri space.
-        Note that Scaled/unscaled relates to the allow_smri_scaling option in coreg.
-        If allow_scaling was False, then the unscaled MRI will be the same as the scaled.
-        MRI.
     """
     logger.info("beamforming")
 
@@ -504,6 +489,7 @@ def parcellate(
     orthogonalisation,
     spatial_resolution=None,
     reference_brain="mni",
+    extra_chans="stim",
 ):
     """Wrapper function for parcellation.
 
@@ -539,6 +525,9 @@ def parcellate(
         Note that Scaled/unscaled relates to the allow_smri_scaling option in coreg.
         If allow_scaling was False, then the unscaled MRI will be the same as the
         scaled MRI.
+    extra_chans : str or list of str
+        Extra channels to include in the parc-raw.fif file. Defaults to 'stim'.
+        Stim channels are always added to parc-raw.fif in addition to extra_chans.
     """
     logger.info("parcellate")
 
@@ -614,7 +603,9 @@ def parcellate(
         # Save parcellated data as a MNE Raw object
         parc_fif_file = src_dir / subject / "rhino/parc-raw.fif"
         logger.info(f"saving {parc_fif_file}")
-        parc_raw = parcellation.convert2mne_raw(parcel_data, data)
+        parc_raw = parcellation.convert2mne_raw(
+            parcel_data, data, extra_chans=extra_chans
+        )
         parc_raw.save(parc_fif_file, overwrite=True)
     else:
         # Save parcellated data as a MNE Epochs object
@@ -666,6 +657,7 @@ def beamform_and_parcellate(
     orthogonalisation,
     spatial_resolution=None,
     reference_brain="mni",
+    extra_chans="stim",
 ):
     """Wrapper function for beamforming and parcellation.
 
@@ -708,6 +700,9 @@ def beamform_and_parcellate(
         Note that Scaled/unscaled relates to the allow_smri_scaling option in coreg.
         If allow_scaling was False, then the unscaled MRI will be the same as the
         scaled MRI.
+    extra_chans : str or list of str
+        Extra channels to include in the parc-raw.fif file. Defaults to 'stim'.
+        Stim channels are always added to parc-raw.fif in addition to extra_chans.
     """
     logger.info("beamform_and_parcellate")
 
@@ -793,7 +788,9 @@ def beamform_and_parcellate(
         # Save parcellated data as a MNE Raw object
         parc_fif_file = src_dir / subject / "rhino/parc-raw.fif"
         logger.info(f"saving {parc_fif_file}")
-        parc_raw = parcellation.convert2mne_raw(parcel_data, data)
+        parc_raw = parcellation.convert2mne_raw(
+            parcel_data, data, extra_chans=extra_chans
+        )
         parc_raw.save(parc_fif_file, overwrite=True)
     else:
         # Save parcellated data as a MNE Epochs object

--- a/osl/utils/logger.py
+++ b/osl/utils/logger.py
@@ -123,14 +123,18 @@ def get_level(handler='console'):
             return handler.level
 
 
-def log_or_print(msg):
+def log_or_print(msg, warning=False):
     """Execute logger.info if an OSL logger has been setup, otherwise print.
 
     Parameters
     ----------
     msg : str
         Message to log/print.
+    warning : bool
+        Is the msg a warning? Defaults to False, which will print info.
     """
+    if warning:
+        msg = f"WARNING: {msg}"
     if hasattr(osl_logger, "already_setup"):
         osl_logger.info(msg)
     else:


### PR DESCRIPTION
Changes:
- We should not include bad segments in the voxel time series at the parcellation step. The current code reproduces the parcel data we generated in the previous code when we were saving as npy files.
- Modified the interface for saving extra channels to the `parc-raw.fif` file.
- Updated sign flipping to work on channels named `parcel_..`, this is useful in case we have other channels of type misc in parc-raw.fif.
- Added a warning if no stim channel was added to `parc-raw.fif`