### PR TITLE
Final OSL Workshop 23 Conda Env

### DIFF
--- a/envs/osl-workshop-23.yml
+++ b/envs/osl-workshop-23.yml
@@ -36,10 +36,10 @@ dependencies:
   - nibabel==5.0.1
   - pandas==1.5.3
   - panel==0.14.4
-  - pre-commit==3.2.0
   - pqdm==0.2.0
   - seaborn==0.12.2
   - tensorflow_probability==0.17.0
   - tqdm==4.65.0
-  - osl==0.2.0
-  - osl-dynamics==1.2.0
+  - osfclient==0.0.5
+  - osl==0.3.0
+  - osl-dynamics==1.2.1


### PR DESCRIPTION
Changes:
- Updated osl to 0.3.0.
- Updated osl-dynamics to 1.2.1.
- Removed pre-commit (no longer a dependency of osl-dynamics).
- Added osfclient to help workshop attendees download data directly from OSF.