### PR TITLE
Added option to omit step 1 in rhino.surfaces.compute_surfaces

### DIFF
--- a/osl/source_recon/rhino/coreg.py
+++ b/osl/source_recon/rhino/coreg.py
@@ -927,7 +927,7 @@ def coreg_display(
 
             # Polhemus-derived nasion, rpa, lpa
             if polhemus_nasion_meg is not None and len(polhemus_nasion_meg.T) > 0:
-                color, scale, alpha = "pink", 0.012, 1.5
+                color, scale, alpha = "pink", 0.012, 1
                 for data in [
                     polhemus_nasion_meg.T,
                     polhemus_rpa_meg.T,

--- a/osl/source_recon/rhino/surfaces.py
+++ b/osl/source_recon/rhino/surfaces.py
@@ -90,6 +90,7 @@ def compute_surfaces(
     include_nose=True,
     cleanup_files=True,
     recompute_surfaces=False,
+    do_mri2mniaxes_xform=True,
 ):
     """Compute surfaces.
 
@@ -146,6 +147,10 @@ def compute_surfaces(
     recompute_surfaces : bool
         Specifies whether or not to run compute_surfaces if the passed in
         options have already been run.
+    do_mri2mniaxes_xform : bool
+        Specifies whether to do step 1) above, i.e. transform sMRI to be
+        aligned with the MNI axes. Sometimes needed when the sMRI goes out
+        of the MNI FOV after step 1).
     """
 
     # Note the jargon used varies for xforms and coord spaces, e.g.:
@@ -243,9 +248,12 @@ please check output of:\n fslorient -getorient {}".format(
     # so that its voxel indices axes are aligned to MNI's
     # This helps BET work.
     # CALCULATE mri2mniaxes
-    flirt_mri2mniaxes_xform = rhino_utils._get_flirt_xform_between_axes(
-        filenames["smri_file"], filenames["std_brain"]
-    )
+    if do_mri2mniaxes_xform:
+        flirt_mri2mniaxes_xform = rhino_utils._get_flirt_xform_between_axes(
+            filenames["smri_file"], filenames["std_brain"]
+        )
+    else:
+        flirt_mri2mniaxes_xform = np.eye(4)
 
     # Write xform to disk so flirt can use it
     flirt_mri2mniaxes_xform_file = op.join(
@@ -603,7 +611,7 @@ please check output of:\n fslorient -getorient {}".format(
         )
 
     log_or_print(
-        'rhino.surfaces_display("{}", "{}") can be used to check the result'.format(
+        'rhino.surfaces.surfaces_display("{}", "{}") can be used to check the result'.format(
             subjects_dir, subject
         )
     )

--- a/osl/source_recon/wrappers.py
+++ b/osl/source_recon/wrappers.py
@@ -85,6 +85,7 @@ def compute_surfaces(
     epoch_file,
     include_nose=True,
     recompute_surfaces=False,
+    do_mri2mniaxes_xform=True,
 ):
     """Wrapper for computing surfaces.
 
@@ -105,6 +106,11 @@ def compute_surfaces(
     recompute_surfaces : bool
         Specifies whether or not to run compute_surfaces, if the passed in
         options have already been run
+    do_mri2mniaxes_xform : bool
+        Specifies whether to do step 1) of compute_surfaces, i.e. transform 
+        sMRI to be aligned with the MNI axes. 
+        Sometimes needed when the sMRI goes out of the MNI FOV after step 1).
+
     """
     # Compute surfaces
     rhino.compute_surfaces(
@@ -113,6 +119,7 @@ def compute_surfaces(
         subject=subject,
         include_nose=include_nose,
         recompute_surfaces=recompute_surfaces,
+        do_mri2mniaxes_xform=do_mri2mniaxes_xform,
     )
 
     # Save info for the report
@@ -121,6 +128,8 @@ def compute_surfaces(
         {
             "compute_surfaces": True,
             "include_nose": include_nose,
+            "do_mri2mniaxes_xform": do_mri2mniaxes_xform,
+        
         },
     )
 
@@ -272,6 +281,7 @@ def compute_surfaces_coregister_and_forward_model(
     smri_file,
     epoch_file,
     include_nose=True,
+    do_mri2mniaxes_xform=True,
     use_nose=True,
     use_headshape=True,
     model="Single Layer",
@@ -297,6 +307,10 @@ def compute_surfaces_coregister_and_forward_model(
         Path to epoched preprocessed fif file.
     include_nose : bool
         Should we include the nose when we're extracting the surfaces?
+    do_mri2mniaxes_xform : bool
+        Specifies whether to do step 1) of compute_surfaces, i.e. transform 
+        sMRI to be aligned with the MNI axes. 
+        Sometimes needed when the sMRI goes out of the MNI FOV after step 1).        
     use_nose : bool
         Should we use the nose in the coregistration?
     use_headshape : bool
@@ -327,6 +341,7 @@ def compute_surfaces_coregister_and_forward_model(
         subject=subject,
         include_nose=include_nose,
         recompute_surfaces=recompute_surfaces,
+        do_mri2mniaxes_xform=do_mri2mniaxes_xform,
     )
 
     # Run coregistration
@@ -371,6 +386,7 @@ def compute_surfaces_coregister_and_forward_model(
             "coregister": True,
             "forward_model": True,
             "include_nose": include_nose,
+            "do_mri2mniaxes_xform": do_mri2mniaxes_xform,
             "use_nose": use_nose,
             "use_headshape": use_headshape,
             "already_coregistered": already_coregistered,


### PR DESCRIPTION
Added new option to compute_surfaces so that the first step can be turned off.

New option is:

do_mri2mniaxes_xform : bool
        Specifies whether to do step 1), i.e. transform sMRI to be
        aligned with the MNI axes. Sometimes needed when the sMRI goes out
        of the MNI FOV after step 1).


Note that the default behaviour for compute_surfaces is as before, i.e. to do step 1 by virtue of do_mri2mniaxes_xform having a default value of True