### PR TITLE
Source Reconstruction Fixes

### DIFF
--- a/osl/source_recon/parcellation/parcellation.py
+++ b/osl/source_recon/parcellation/parcellation.py
@@ -771,6 +771,10 @@ def convert2niftii(parc_data, parcellation_file, mask_file, tres=1, tmin=0):
     if len(parc_data.shape) == 1:
         parc_data = np.reshape(parc_data, [1, -1])
 
+    # Find files within the package
+    parcellation_file = find_file(parcellation_file)
+    mask_file = find_file(mask_file)
+
     # Load the mask
     mask = nib.load(mask_file)
     mask_grid = mask.get_fdata()

--- a/osl/source_recon/parcellation/parcellation.py
+++ b/osl/source_recon/parcellation/parcellation.py
@@ -862,7 +862,7 @@ def convert2mne_raw(parc_data, raw, parcel_names=None, extra_chans="stim"):
     # parc_data is missing bad segments
     # We insert these before creating the new MNE object
     _, times = raw.get_data(reject_by_annotation="omit", return_times=True)
-    indices = raw.time_as_index(times)
+    indices = raw.time_as_index(times, use_rounding=True)
     data = np.zeros([parc_data.shape[0], len(raw.times)], dtype=np.float32)
     data[:, indices] = parc_data
 


### PR DESCRIPTION
Sometimes `raw.time_as_index` miss assigns the index that corresponds to a particular time point. For example, using
```
times = [0, 0.1, 0.2, 0.3, 0.4, …]
indices = raw.time_as_index(times)
```
You might get something like
```
indices = [0, 1, 1, 3, 4, …]
```
Rather than what you really want, which is `indices = [0, 1, 2, 3, 4, …]`.

We resolve this issue in this PR by passing `raw.time_as_index(times, use_rounding=True)`.