### PR TITLE
Changed coregistration defaults (n_init)

### DIFF
--- a/osl/source_recon/rhino/coreg.py
+++ b/osl/source_recon/rhino/coreg.py
@@ -117,7 +117,7 @@ def coreg(
     use_dev_ctf_t=True,
     already_coregistered=False,
     allow_smri_scaling=False,
-    n_init=30,
+    n_init=1,
 ):
     """Coregistration.
 

--- a/osl/source_recon/wrappers.py
+++ b/osl/source_recon/wrappers.py
@@ -144,7 +144,7 @@ def coregister(
     use_headshape=True,
     already_coregistered=False,
     allow_smri_scaling=False,
-    n_init=30,
+    n_init=1,
 ):
     """Wrapper for coregistration.
 
@@ -288,7 +288,7 @@ def compute_surfaces_coregister_and_forward_model(
     recompute_surfaces=False,
     already_coregistered=False,
     allow_smri_scaling=False,
-    n_init=30,
+    n_init=1,
     eeg=False,
 ):
     """Wrapper for: compute_surfaces, coregister and forward_model.


### PR DESCRIPTION
`n_init=30` often causes over rotation of the head when matching to the headshape points. On multiple datasets, using `n_init=1` as the default gives (much) better coreg.

Note, it's straightforward for the user to specify a higher `n_init` by passing this arguments to `rhino.coreg.coreg` or in the source reconstruction config.