### PR TITLE
[Fix #218] enable user specification of file extension

### DIFF
--- a/osl/preprocessing/batch.py
+++ b/osl/preprocessing/batch.py
@@ -815,7 +815,7 @@ def run_proc_batch(
     outdir=None,
     logsdir=None,
     reportdir=None,
-    gen_report=Tr3ue,
+    gen_report=True,
     overwrite=False,
     extra_funcs=None,
     verbose="INFO",

--- a/osl/preprocessing/batch.py
+++ b/osl/preprocessing/batch.py
@@ -417,11 +417,11 @@ def read_dataset(fif, preload=False, ftype=None):
             logger.info('Assuming fif file type is "preproc_raw"')
             ftype = "preproc_raw"
         else:
-            try:
-                ftype = fif.split("_")[-1].split('.')[-2]
-                logger.info('Assuming fif file type is the last "_" separated string')
-            except:
+            if len(fif.split("_"))<2:
                 logger.error("Unable to guess the fif file extension")
+            else:
+                logger.info('Assuming fif file type is the last "_" separated string')
+                ftype = fif.split("_")[-1].split('.')[-2]
     
     # add extension to fif file name
     ftype = ftype + ".fif"

--- a/osl/preprocessing/batch.py
+++ b/osl/preprocessing/batch.py
@@ -333,7 +333,7 @@ def append_preproc_info(dataset, config):
     return dataset
 
 
-def write_dataset(dataset, outbase, run_id, overwrite=False):
+def write_dataset(dataset, outbase, run_id, ftype='preproc_raw', overwrite=False):
     """Write preprocessed data to a file.
 
     Parameters
@@ -344,6 +344,8 @@ def write_dataset(dataset, outbase, run_id, overwrite=False):
         Path to directory to write to.
     run_id : str
         ID for the output file.
+    ftype: str
+        Extension for the fif file (default "preproc_raw")
     overwrite : bool
         Should we overwrite if the file already exists?
 
@@ -358,7 +360,7 @@ def write_dataset(dataset, outbase, run_id, overwrite=False):
         if string in run_id:
             run_id = run_id.replace(string, "")
 
-    fif_outname = outbase.format(run_id=run_id, ftype="preproc_raw", fext="fif")
+    fif_outname = outbase.format(run_id=run_id, ftype=ftype, fext="fif")
     if Path(fif_outname).exists() and not overwrite:
         raise ValueError(
             "{} already exists. Please delete or do use overwrite=True.".format(fif_outname)
@@ -383,7 +385,7 @@ def write_dataset(dataset, outbase, run_id, overwrite=False):
 
     return fif_outname
 
-def read_dataset(fif, preload=False):
+def read_dataset(fif, preload=False, ftype=None):
     """Reads fif/npy/yml files associated with a dataset.
 
     Parameters
@@ -392,6 +394,11 @@ def read_dataset(fif, preload=False):
         Path to raw fif file (can be preprocessed).
     preload : bool
         Should we load the raw fif data?
+    ftype : str
+        Extension for the fif file (will be replaced for e.g. "_events.npy" or 
+        "_ica.fif"). If None, we assume the fif file is preprocessed with 
+        OSL and has the extension "preproc_raw". If this fails, we guess 
+        the extension as whatever comes after the last "_".
 
     Returns
     -------
@@ -403,14 +410,31 @@ def read_dataset(fif, preload=False):
     print("Reading", fif)
     raw = mne.io.read_raw_fif(fif, preload=preload)
 
-    events = Path(fif.replace("preproc_raw.fif", "events.npy"))
+    # Guess extension
+    if ftype is None:
+        logger.info("Guessing the preproc extension")
+        if "preproc_raw" in fif:
+            logger.info('Assuming fif file type is "preproc_raw"')
+            ftype = "preproc_raw"
+        else:
+            try:
+                ftype = fif.split("_")[-1].split('.')[-2]
+                logger.info('Assuming fif file type is the last "_" separated string')
+            except:
+                logger.error("Unable to guess the fif file extension")
+    
+    # add extension to fif file name
+    ftype = ftype + ".fif"
+     
+    
+    events = Path(fif.replace(ftype, "events.npy"))
     if events.exists():
         print("Reading", events)
         events = np.load(events)
     else:
         events = None
 
-    event_id = Path(fif.replace("preproc_raw.fif", "event-id.yml"))
+    event_id = Path(fif.replace(ftype, "event-id.yml"))
     if event_id.exists():
         print("Reading", event_id)
         with open(event_id, "r") as file:
@@ -418,14 +442,14 @@ def read_dataset(fif, preload=False):
     else:
         event_id = None
 
-    epochs = Path(fif.replace("preproc_raw", "epo"))
+    epochs = Path(fif.replace(ftype, "epo.fif"))
     if epochs.exists():
         print("Reading", epochs)
         epochs = mne.read_epochs(epochs)
     else:
         epochs = None
 
-    ica = Path(fif.replace("preproc_raw", "ica"))
+    ica = Path(fif.replace(ftype, "ica.fif"))
     if ica.exists():
         print("Reading", ica)
         ica = mne.preprocessing.read_ica(ica)
@@ -552,6 +576,7 @@ def run_proc_chain(
     config,
     infile,
     outname=None,
+    ftype='preproc_raw',
     outdir=None,
     logsdir=None,
     reportdir=None,
@@ -572,6 +597,8 @@ def run_proc_chain(
         Path to input file.
     outname : str
         Output filename.
+    ftype: str
+        Extension for the fif file (default "preproc_raw")
     outdir : str
         Output directory. If processing multiple files, they can
         be put in unique sub directories by including {x:0} at 
@@ -628,7 +655,7 @@ def run_proc_chain(
         gen_report = True if gen_report is None else gen_report
         
         # Create output directories if they don't exist
-        outdir = add_subdir(infile, outdir, run_id)
+        # outdir = add_subdir(infile, outdir, run_id)
         outdir = validate_outdir(outdir)
         logsdir = validate_outdir(logsdir or outdir / "logs")
         reportdir = validate_outdir(reportdir or outdir / "report")
@@ -655,7 +682,7 @@ def run_proc_chain(
     if logsdir is not None:
         logbase = os.path.join(logsdir, name_base)
         logfile = logbase.format(
-            run_id=run_id.replace("_raw", ""), ftype="preproc_raw", fext="log"
+            run_id=run_id.replace("_raw", ""), ftype=ftype, fext="log"
         )
         mne.utils._logging.set_log_file(logfile, overwrite=overwrite)
     else:
@@ -673,7 +700,7 @@ def run_proc_chain(
     if outdir is not None:
         # Check for existing outputs - should be a .fif at least
         fifout = outbase.format(
-            run_id=run_id.replace('_raw', ''), ftype='preproc_raw', fext='fif'
+            run_id=run_id.replace('_raw', ''), ftype=ftype, fext='fif'
         )
         if os.path.exists(fifout) and (overwrite is False):
             logger.critical('Skipping preprocessing - existing output detected')
@@ -788,13 +815,14 @@ def run_proc_batch(
     outdir=None,
     logsdir=None,
     reportdir=None,
-    gen_report=True,
+    gen_report=Tr3ue,
     overwrite=False,
     extra_funcs=None,
     verbose="INFO",
     mneverbose="WARNING",
     strictrun=False,
     dask_client=False,
+    ftype=None,
 ):
     """Run batched preprocessing.
 

--- a/osl/preprocessing/batch.py
+++ b/osl/preprocessing/batch.py
@@ -655,7 +655,7 @@ def run_proc_chain(
         gen_report = True if gen_report is None else gen_report
         
         # Create output directories if they don't exist
-        # outdir = add_subdir(infile, outdir, run_id)
+        outdir = add_subdir(infile, outdir, run_id)
         outdir = validate_outdir(outdir)
         logsdir = validate_outdir(logsdir or outdir / "logs")
         reportdir = validate_outdir(reportdir or outdir / "report")

--- a/osl/report/raw_report.py
+++ b/osl/report/raw_report.py
@@ -40,7 +40,7 @@ from ..preprocessing import (
 # Report generation
 
 
-def gen_report_from_fif(infiles, outdir):
+def gen_report_from_fif(infiles, outdir, ftype=None):
     """Generate web-report for a set of MNE data objects.
 
     Parameters
@@ -49,6 +49,9 @@ def gen_report_from_fif(infiles, outdir):
         List of paths to fif files.
     outdir : str
         Directory to save HTML report and figures to.
+    ftype : str
+        Type of fif file, e.g., 'raw' or 'preproc_raw'.
+        
     """
 
     # Validate input files and directory to save html file and plots to
@@ -58,7 +61,7 @@ def gen_report_from_fif(infiles, outdir):
     # Generate HTML data
     for infile in infiles:
         print("Generating report for", infile)
-        dataset = read_dataset(infile)
+        dataset = read_dataset(infile, ftype=ftype)
         run_id = get_header_id(dataset['raw'])
         htmldatadir = validate_outdir(outdir / run_id)
         gen_html_data(dataset['raw'], htmldatadir, ica=dataset['ica'])


### PR DESCRIPTION
Fixes #218 
Instead of assuming that all preprocessed MEG files are called `..._preproc_raw.fif`, we enable user input by specifying `ftype` in functions `run_proc_chain`, `run_proc_batch`, `write_dateset`, `read_dataset`, and `gen_report_from_fif`. If this is not specified, it will try using `preproc_raw` anyway, and otherwise guess whatever comes in between the last `_` and `.fif`. 