### PR TITLE
Fix: save the SSP cleaned data (rather than the original data).

### DIFF
--- a/examples/oxford/ssp_pipeline/3_ssp_denoise.py
+++ b/examples/oxford/ssp_pipeline/3_ssp_denoise.py
@@ -108,4 +108,4 @@ for index in range(len(preproc_files)):
         plt.close()
 
     # Save cleaned data
-    dataset["raw"].save(output_raw_file, overwrite=True)
+    raw_ssp.save(output_raw_file, overwrite=True)


### PR DESCRIPTION
Fixed a bug where we didn't save the cleaned data in an example script.