### PR TITLE
Fix tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ HERE = pathlib.Path(__file__).parent
 README = (HERE / "README.md").read_text()
 
 # Requirement categories
-reqs = ['numpy', 'scipy', 'matplotlib', 'mne>=1.0.0', 'scikit-learn', 'fslpy',
+reqs = ['numpy', 'scipy', 'matplotlib', 'mne~=1.3.1', 'scikit-learn', 'fslpy',
         'sails', 'tabulate', 'pyyaml>=5.1', 'neurokit2', 'jinja2==3.0.3',
         'glmtools', 'numba', 'nilearn', 'dask', 'distributed', 'parse',
         'opencv-python', 'panel', 'h5io']


### PR DESCRIPTION
Closes https://github.com/OHBA-analysis/osl/issues/241.

This fixes the tests by pinning down MNE to something close to v1.3. 

TODO: In the future we will need to fix the imports to be compatible with newer versions of MNE and update the version in the dependencies.