### PR TITLE
Update glm_spectrum.py

### DIFF
--- a/osl/glm/glm_spectrum.py
+++ b/osl/glm/glm_spectrum.py
@@ -728,9 +728,9 @@ def plot_joint_spectrum(xvect, psd, info, ax=None, freqs='auto', base=1,
     fx = prep_scaled_freq(base, xvect)
 
     if freqs == 'auto':
-        topo_freq_inds = signal.find_peaks(psd.mean(axis=1), distance=xvect.shape[0]/3)[0]
+        topo_freq_inds = signal.find_peaks(np.abs(psd.mean(axis=1)), distance=xvect.shape[0]/3)[0]
         if len(topo_freq_inds) > 2:
-            I = np.argsort(psd.mean(axis=1)[topo_freq_inds])[-2:]
+            I = np.argsort(np.abs(psd.mean(axis=1))[topo_freq_inds])[-2:]
             topo_freq_inds = topo_freq_inds[I]
         freqs = xvect[topo_freq_inds]
     else:


### PR DESCRIPTION
`plot_joint_spectrum` by default automatically determines which topo's to plot. However, it only looks for positive peaks, while it is probably more reasonable to look for any extrema (especially when plotting contrasts, or EEG data).  With these changes, `find_peaks` is applied to the absolute data.