### PR TITLE
Update polhemus.py

### DIFF
--- a/osl/source_recon/rhino/polhemus.py
+++ b/osl/source_recon/rhino/polhemus.py
@@ -158,6 +158,7 @@ def delete_headshape_points(recon_dir=None, subject=None, polhemus_headshape_fil
         polhemus_headshape_file = coreg_filenames["polhemus_headshape_file"]
     elif polhemus_headshape_file is not None:
         polhemus_headshape_file = polhemus_headshape_file
+        coreg_filenames = {'polhemus_headshape_file': polhemus_headshape_file}
     else:
         ValueError('Invalid inputs. See function\'s documentation.')
       


### PR DESCRIPTION
Fix `delete_headshape_points` when only headshape file is provided. Previously, this would result in an error whenever the data is saved because of an undefined variable.