### PR TITLE
osl_func utility: run any function from the command line

### DIFF
--- a/osl/utils/__init__.py
+++ b/osl/utils/__init__.py
@@ -9,6 +9,7 @@ from .parallel import dask_parallel_bag  # noqa: F401, F403
 from .simulate import *  # noqa: F401, F403
 from .opm import *  # noqa: F401, F403
 from .package import soft_import, run_package_tests  # noqa: F401, F403
+from . import run_func  # noqa: F401, F403
 
 with open(os.path.join(os.path.dirname(__file__), "README.md"), 'r') as f:
     __doc__ = f.read()

--- a/osl/utils/run_func.py
+++ b/osl/utils/run_func.py
@@ -1,0 +1,38 @@
+from functools import partial
+import sys
+
+def main(argv=None):
+    # sys.argv[1] is the function name
+    # sys.argv[2:] are the arguments to the function
+    # e.g. python -m osl.utils.run_func my_func arg1 arg2
+    # will call my_func(arg1, arg2)
+    if argv is None:
+        argv = sys.argv[1:]
+    
+    func_name = argv[0]
+    func_args = argv[1:]
+    
+    # iteratively open each (sub)module
+    for ii, mod in enumerate(func_name.split('.')):
+        if ii==0:
+            module = __import__(mod)
+        else:
+            module = getattr(module, mod)
+    func = module
+
+    # do some general argument checks
+    for ii in range(len(func_args)):
+        if type(func_args[ii]) is str:
+            if func_args[ii]=='None':
+                func_args[ii] = None
+            elif func_args[ii]=='True':
+                func_args[ii] = True
+            elif func_args[ii]=='False':
+                func_args[ii] = False
+    
+    # run the function
+    func(*func_args)
+    
+    
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(name=name,
           'console_scripts': [
               'osl_maxfilter = osl.maxfilter.maxfilter:main',
               'osl_preproc = osl.preprocessing.batch:main',
+              'osl_func = osl.utils.run_func:main',
           ]},
 
       packages=['osl', 'osl.tests', 'osl.report', 'osl.maxfilter',


### PR DESCRIPTION
This is a utility function addition to run any osl function (with limitations) from the terminal command line, i.e.,  `osl_func function_name arg1 arg2`. 
Example: 
`osl_func osl.source_recon.rhino.polhemus.delete_headshape_points None None polhemus_headshape.txt` will iteratively load the (sub-) module until it reaches the function, and then run the function with the function arguments. This example will run  `osl.source_recon.rhino.polhemus.delete_headshape_points(recon_dir=None, subject=None, polhemus_headshape_file='polhemus_headshape.txt')`.

This is especially useful for interactive functions, which often don't work very well in Jupyter Notebook. Because I expect that this is an issue that many people will face, I thought this would be useful (so users don't have to make separate scripts for this purpose every time). The main limitation currently is that you can only use functions with string, boolean, or None arguments.