### PR TITLE
Improve report

### DIFF
--- a/osl/preprocessing/batch.py
+++ b/osl/preprocessing/batch.py
@@ -22,6 +22,7 @@ from copy import deepcopy
 from functools import partial, wraps
 from time import localtime, strftime
 from datetime import datetime
+import inspect
 
 import mne
 import numpy as np
@@ -299,7 +300,7 @@ def get_config_from_fif(inst):
     return config
 
 
-def append_preproc_info(dataset, config):
+def append_preproc_info(dataset, config, extra_funcs=None):
     """Add to the config of already preprocessed data to ``inst.info['description']``.
 
     Parameters
@@ -325,6 +326,12 @@ def append_preproc_info(dataset, config):
         + f"VERSION: {__version__}\n"
         + f"%% config start %% \n{config} \n%% config end %%"
     )
+    
+    if extra_funcs is not None:
+        preproc_info += "\n\nCUSTOM FUNCTIONS USED:\n"
+        for func in extra_funcs:
+            preproc_info += f"%% extra_funcs start %% \n{inspect.getsource(func)}\n%% extra_funcs end %%"
+    
     dataset["raw"].info["description"] = (
         dataset["raw"].info["description"] + preproc_info
     )
@@ -745,7 +752,7 @@ def run_proc_chain(
             dataset = func(dataset, userargs)
 
         # Add preprocessing info to dataset dict
-        dataset = append_preproc_info(dataset, config)
+        dataset = append_preproc_info(dataset, config, extra_funcs)
 
         fif_outname = None
         if outdir is not None:

--- a/osl/report/preproc_report.py
+++ b/osl/report/preproc_report.py
@@ -814,13 +814,12 @@ def plot_spectra(raw, savebase=None):
             continue
 
         # Plot spectra
-        raw.plot_psd(
-            show=False,
-            picks=chan_inds,
-            ax=ax[row],
+        raw.compute_psd(
+            picks=chan_inds, 
             n_fft=int(raw.info['sfreq']*2),
-            verbose=0,
-        )
+            verbose=0).plot(
+                        axes=ax[row],
+                        show=False)
 
         ax[row].set_title(name, fontsize=12)
 
@@ -843,15 +842,14 @@ def plot_spectra(raw, savebase=None):
             continue
 
         # Plot zoomed in spectra
-        raw.plot_psd(
-            show=False,
-            picks=chan_inds,
-            ax=ax[row],
-            fmin=1,
-            fmax=48,
-            n_fft=int(raw.info['sfreq']*2),
-            verbose=0,
-        )
+        raw.compute_psd(
+        picks=chan_inds, 
+        fmin=1,
+        fmax=48,
+        n_fft=int(raw.info['sfreq']*2),
+        verbose=0).plot(
+                    axes=ax[row],
+                    show=False)
 
         ax[row].set_title(name, fontsize=12)
 

--- a/osl/report/preproc_report.py
+++ b/osl/report/preproc_report.py
@@ -194,6 +194,7 @@ def gen_html_data(raw, outdir, ica=None, preproc_fif_filename=None):
     # Generate plots for the report
     data["plt_config"] = plot_flowchart(raw, savebase)
     data["txt_extra_funcs"] = save_extra_funcs(raw, savebase.replace('.png', '.txt'))
+    data["plt_rawdata"] = plot_rawdata(raw, savebase)
     data['plt_temporalsumsq'] = plot_channel_time_series(raw, savebase, exclude_bads=False)
     data['plt_temporalsumsq_exclude_bads'] = plot_channel_time_series(raw, savebase, exclude_bads=True)
     data['plt_badchans'] = plot_sensors(raw, savebase)
@@ -454,6 +455,39 @@ def save_extra_funcs(raw, savebase=None):
         return None
     
         
+
+def plot_rawdata(raw, savebase):
+    """Plots raw data.
+    
+    Parameters
+    ----------
+    raw : :py:class:`mne.io.Raw <mne.io.Raw>`
+        MNE Raw object.
+    savebase : str
+        Base string for saving figures.
+        
+    Returns
+    -------
+    fpath : str
+        Path to saved figure.      
+    
+    """
+
+    fig = raw.pick(['meg', 'eeg']).plot(n_channels=np.inf, duration=raw.times[-1])
+
+    if savebase is not None:
+        figname = savebase.format('rawdata')
+        fig.savefig(figname, dpi=150, transparent=True)
+        plt.close(fig)
+
+        # Return the filename
+        savebase = pathlib.Path(savebase)
+        filebase = savebase.parent.name + "/" + savebase.name
+        fpath = filebase.format('rawdata')
+    else:
+        fpath = None
+    return fpath
+
 
 def plot_channel_time_series(raw, savebase=None, exclude_bads=False):
     """Plots sum-square time courses.

--- a/osl/report/src_report.py
+++ b/osl/report/src_report.py
@@ -3,6 +3,7 @@
 """
 
 # Authors: Chetan Gohil <chetan.gohil@psych.ox.ac.uk>
+# Mats van Es <mats.vanes@psych.ox.ac.uk>
 
 import os
 import os.path as op
@@ -13,12 +14,13 @@ import pickle
 import numpy as np
 import matplotlib.pyplot as plt
 from tabulate import tabulate
+import inspect
 
 from . import preproc_report
 from ..source_recon import parcellation
 
 
-def gen_html_data(config, src_dir, subject, reportdir, logger=None):
+def gen_html_data(config, src_dir, subject, reportdir, logger=None, extra_funcs=None):
     """Generate data for HTML report.
 
     Parameters
@@ -33,6 +35,8 @@ def gen_html_data(config, src_dir, subject, reportdir, logger=None):
         Report directory.
     logger : logging.getLogger
         Logger.
+    extra_funcs : list
+        List of extra functions to run
     """
     src_dir = Path(src_dir)
     reportdir = Path(reportdir)
@@ -63,6 +67,8 @@ def gen_html_data(config, src_dir, subject, reportdir, logger=None):
         data = {}
         data["config"] = config
 
+    data['extra_funcs'] = save_extra_funcs(extra_funcs, reportdir / subject)
+    
     data["fif_id"] = subject
     data["filename"] = subject
 
@@ -114,6 +120,31 @@ def gen_html_data(config, src_dir, subject, reportdir, logger=None):
 
     # Save data in the report directory
     pickle.dump(data, open(f"{reportdir}/{subject}/data.pkl", "wb"))
+
+
+def save_extra_funcs(extra_funcs, reportdir):
+    """ Saves extra functions to a text file.
+    
+    Parameters
+    ----------
+    extra_funcs : list
+        List of extra functions to save.
+    reportdir : str
+        Subject report directory.
+        
+    Returns
+    -------
+    fpath : str
+        Path to saved text file.
+    """
+    
+    if reportdir is not None:
+        fpath = reportdir / 'extra_funcs.txt'
+        with(open(fpath, 'w')) as file:
+            [print(f"{inspect.getsource(func)}\n\n", file=file) for func in extra_funcs]
+        return fpath
+    else:
+        return None
 
 
 def gen_html_page(reportdir):
@@ -215,6 +246,7 @@ def gen_html_summary(reportdir):
     data = {}
     data["total"] = total
     data["config"] = subject_data[0]["config"]
+    data["extra_funcs"] = subject_data[0]["extra_funcs"]
     data["coregister"] = subject_data[0]["coregister"]
     data["beamform"] = subject_data[0]["beamform"]
     data["beamform_and_parcellate"] = subject_data[0]["beamform_and_parcellate"]

--- a/osl/report/templates/raw_subject_panel.html
+++ b/osl/report/templates/raw_subject_panel.html
@@ -49,6 +49,10 @@
     </div>
     
     <div class="tabpage" style="width: 100%; display: none" id={{ data.fif_id }}_timeseries>
+        <div style="width: 100%">
+            <h4>Raw data</h4>
+            <img src="{{ data.plt_rawdata }}" alt="" style='max-width: 60%'/>
+        </div>
         {% if data.bad_seg != [] %}
             <div style="width: 100%">
                 <h4>Bad segments</h4>

--- a/osl/report/templates/raw_summary_panel.html
+++ b/osl/report/templates/raw_summary_panel.html
@@ -14,6 +14,7 @@
     <div class="tabpage" style='width: 100%' id='config'>
         <h3>Config</h3>
         <img src="{{ data.plt_config }}" alt="" style='max-width: 60%'/>
+        <h3>Extra functions</h3>
         <iframe src="{{ data.txt_extra_funcs }}" style="width: 80%; height: 200px;"></iframe>
     </div>
 

--- a/osl/report/templates/raw_summary_panel.html
+++ b/osl/report/templates/raw_summary_panel.html
@@ -14,6 +14,7 @@
     <div class="tabpage" style='width: 100%' id='config'>
         <h3>Config</h3>
         <img src="{{ data.plt_config }}" alt="" style='max-width: 60%'/>
+        <iframe src="{{ data.txt_extra_funcs }}" style="width: 80%; height: 200px;"></iframe>
     </div>
 
     <div class="tabpage" style='width: 100%' id='time'>

--- a/osl/report/templates/src_summary_panel.html
+++ b/osl/report/templates/src_summary_panel.html
@@ -21,6 +21,8 @@
     <div class="tabpage" style='width: 100%' id='config'>
         <h3>Config</h3>
         <img src="{{ data.plt_config }}" alt="" style='max-width: 60%'/>
+        <h3>Extra functions</h3>
+        <iframe src="{{ data.extra_funcs }}" style="width: 80%; height: 200px;"></iframe>
     </div>
 
     {% if data.coregister %}

--- a/osl/source_recon/batch.py
+++ b/osl/source_recon/batch.py
@@ -204,7 +204,7 @@ def run_src_chain(
         return False
 
     # Generate HTML data for the report
-    src_report.gen_html_data(config, src_dir, subject, reportdir)
+    src_report.gen_html_data(config, src_dir, subject, reportdir, extra_funcs=extra_funcs)
 
     return True
 


### PR DESCRIPTION
Summary of changes:

- in `run_proc_chain`, if extra_funcs is given, append the code of each function to `raw.info['description']` (appended after the config text)
- print the extra_funcs code to a scroll box in the preproc and source summary report, underneath the config (see below).
- in preproc_report, replace the legacy `raw.plot_psd()` with `raw.compute_psd().plot()`

![extrafuncs](https://github.com/OHBA-analysis/osl/assets/11160190/8560a7f2-8491-4f3d-b719-59915f65720b)
