### PR TITLE
Option to use qform in surface extraction + minor fixes

### DIFF
--- a/osl/source_recon/rhino/coreg.py
+++ b/osl/source_recon/rhino/coreg.py
@@ -5,7 +5,6 @@
 # Authors: Mark Woolrich <mark.woolrich@ohba.ox.ac.uk>
 #          Chetan Gohil <chetan.gohil@psych.ox.ac.uk>
 
-import os
 import os.path as op
 from pathlib import Path
 from shutil import copyfile

--- a/osl/source_recon/rhino/forward_model.py
+++ b/osl/source_recon/rhino/forward_model.py
@@ -9,8 +9,6 @@ import os
 import os.path as op
 from copy import deepcopy
 
-import nibabel as nib
-
 from mne import make_bem_model, make_bem_solution, make_forward_solution, write_forward_solution
 from mne.bem import ConductorModel, read_bem_solution
 from mne.transforms import read_trans, Transform
@@ -148,7 +146,7 @@ def make_fwd_solution(
 
     # The forward model is done in head space
     # We need the transformation from MRI to HEAD coordinates (or vice versa)
-    head_scaledmri_trans_file = filenames["head_scaledmri_t_file" ]
+    head_scaledmri_trans_file = filenames["head_scaledmri_t_file"]
     if isinstance(head_scaledmri_trans_file, str):
         head_mri_t = read_trans(head_scaledmri_trans_file)
     else:

--- a/osl/source_recon/rhino/polhemus.py
+++ b/osl/source_recon/rhino/polhemus.py
@@ -8,6 +8,7 @@
 
 import os
 import numpy as np
+import pandas as pd
 import matplotlib.pyplot as plt
 
 from mne.io import read_info

--- a/osl/source_recon/rhino/surfaces.py
+++ b/osl/source_recon/rhino/surfaces.py
@@ -5,7 +5,6 @@
 # Authors: Mark Woolrich <mark.woolrich@ohba.ox.ac.uk>
 #          Chetan Gohil <chetan.gohil@psych.ox.ac.uk>
 
-import os
 import os.path as op
 import warnings
 from pathlib import Path

--- a/osl/source_recon/rhino/surfaces.py
+++ b/osl/source_recon/rhino/surfaces.py
@@ -388,7 +388,7 @@ def compute_surfaces(
 
         # Clean up mask
         mask[:, :, 50:300] = morphology.binary_fill_holes(mask[:, :, 50:300])
-        mask[:, :, 50:300] = rhino_utils._binary_majority3d(mask[:, :, 50:300])
+        mask[:, :, 50:300] = rhino_utils.binary_majority3d(mask[:, :, 50:300])
         mask[:, :, 50:300] = morphology.binary_fill_holes(mask[:, :, 50:300])
 
         for i in range(mask.shape[0]):

--- a/osl/source_recon/rhino/surfaces.py
+++ b/osl/source_recon/rhino/surfaces.py
@@ -86,6 +86,7 @@ def compute_surfaces(
     cleanup_files=True,
     recompute_surfaces=False,
     do_mri2mniaxes_xform=True,
+    use_qform=False,
 ):
     """Compute surfaces.
 
@@ -109,22 +110,24 @@ def compute_surfaces(
 
     Parameters
     ----------
-    smri_file : string
+    smri_file : str
         Full path to structural MRI in niftii format (with .nii.gz extension). This is assumed to have a valid sform, i.e. the sform code needs to be 4 or 1, and the sform
         should transform from voxel indices to voxel coords in mm. The axis sform used to do this will be the native/sMRI axis used throughout rhino. The qform will be ignored.
-    subjects_dir : string
+    subjects_dir : str
         Directory to put RHINO subject directories in. Files will be in subjects_dir/subject/surfaces.
-    subject : string
+    subject : str
         Subject name directory to put RHINO files in. Files will be in subjects_dir/subject/surfaces.
-    include_nose : bool
+    include_nose : bool, optional
         Specifies whether to add the nose to the outer skin (scalp) surface. This can help rhino's coreg to work better, assuming that there are headshape points that also
         include the nose. Requires the smri_file to have a FOV that includes the nose!
-    cleanup_files : bool
+    cleanup_files : bool, optional
         Specifies whether to cleanup intermediate files in the coreg directory.
-    recompute_surfaces : bool
+    recompute_surfaces : bool, optional
         Specifies whether or not to run compute_surfaces if the passed in options have already been run.
-    do_mri2mniaxes_xform : bool
+    do_mri2mniaxes_xform : bool, optional
         Specifies whether to do step 1) above, i.e. transform sMRI to be aligned with the MNI axes. Sometimes needed when the sMRI goes out of the MNI FOV after step 1).
+    use_qform : bool, optional
+        Should we replace the sform with the qform? Useful if the sform code is incompatible with OSL, but the qform is compatible.
 
     Returns
     -------
@@ -168,9 +171,12 @@ def compute_surfaces(
 
     # RHINO will always use the sform, and so we will set the qform to be same as sform for sMRI,
     # to stop the original qform from being used by mistake (e.g. by flirt)
-    #
-    # Command: fslorient -copysform2qform <smri_file>
-    fsl_wrappers.misc.fslorient(filenames['smri_file'], copysform2qform=True)
+    if use_qform:
+        # Command: fslorient -copyqform2sform <smri_file>
+        fsl_wrappers.misc.fslorient(filenames['smri_file'], copyqform2sform=True)
+    else:
+        # Command: fslorient -copysform2qform <smri_file>
+        fsl_wrappers.misc.fslorient(filenames['smri_file'], copysform2qform=True)
 
     # We will assume orientation of standard brain is RADIOLOGICAL. But let's check that is the case:
     std_orient = rhino_utils.get_orient(filenames["std_brain"])

--- a/osl/source_recon/rhino/utils.py
+++ b/osl/source_recon/rhino/utils.py
@@ -286,7 +286,7 @@ def get_sform(nii_file):
     else:
         raise ValueError(
             f"sform code for {nii_file} is {sformcode}, and needs to be 4 or 1.\n"
-            "To fix see: https://github.com/OHBA-analysis/osl/blob/main/examples/miscellaneous/fix_smri_files.py"
+            "To fix see: https://github.com/OHBA-analysis/osl/blob/main/examples/misc/fix_smri_files.py"
         )
 
     sform = Transform("mri_voxel", "mri", sform)

--- a/osl/source_recon/rhino/utils.py
+++ b/osl/source_recon/rhino/utils.py
@@ -286,7 +286,8 @@ def get_sform(nii_file):
     else:
         raise ValueError(
             f"sform code for {nii_file} is {sformcode}, and needs to be 4 or 1.\n"
-            "To fix see: https://github.com/OHBA-analysis/osl/blob/main/examples/misc/fix_smri_files.py"
+            "If the qform code is 4 or 1, then considering passing use_qform=True.\n"
+            "Also see: https://github.com/OHBA-analysis/osl/blob/main/examples/misc/fix_smri_files.py"
         )
 
     sform = Transform("mri_voxel", "mri", sform)

--- a/osl/source_recon/rhino/utils.py
+++ b/osl/source_recon/rhino/utils.py
@@ -329,7 +329,7 @@ def majority(values_ptr, len_values, result, data):
     return 1
 
 
-def _binary_majority3d(img):
+def binary_majority3d(img):
     """
     Set a pixel to 1 if a required majority (default=14) or more pixels in its 3x3x3 neighborhood are 1, otherwise, set the pixel to 0. img is a 3D binary image
     """

--- a/osl/source_recon/wrappers.py
+++ b/osl/source_recon/wrappers.py
@@ -242,6 +242,7 @@ def compute_surfaces(
     include_nose=True,
     recompute_surfaces=False,
     do_mri2mniaxes_xform=True,
+    use_qform=False,
 ):
     """Wrapper for computing surfaces.
 
@@ -267,6 +268,9 @@ def compute_surfaces(
         Specifies whether to do step 1) of compute_surfaces, i.e. transform
         sMRI to be aligned with the MNI axes. Sometimes needed when the sMRI
         goes out of the MNI FOV after step 1).
+    use_qform : bool, optional
+        Should we replace the sform with the qform? Useful if the sform code
+        is incompatible with OSL, but the qform is compatible.
     """
     if smri_file == "standard":
         std_struct = "MNI152_T1_2mm.nii.gz"
@@ -281,6 +285,7 @@ def compute_surfaces(
         include_nose=include_nose,
         recompute_surfaces=recompute_surfaces,
         do_mri2mniaxes_xform=do_mri2mniaxes_xform,
+        use_qform=use_qform,
     )
 
     # Plot surfaces
@@ -296,6 +301,7 @@ def compute_surfaces(
             "compute_surfaces": True,
             "include_nose": include_nose,
             "do_mri2mniaxes_xform": do_mri2mniaxes_xform,
+            "use_qform": use_qform,
             "surface_plots": surface_plots,
         },
     )


### PR DESCRIPTION
Changes:
- Added missing imports / removed unused imports.
- Updated the example script to fix structural MRIs.
- Added option to use qform instead of the sform.