### PR TITLE
Fixed Tests

### DIFF
--- a/.github/workflows/osl-cicd-actions.yml
+++ b/.github/workflows/osl-cicd-actions.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.8.16"
 
       - name: Install pipenv
         run: |
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[full]
+          pip install -e .
 
       - name: Run test suite
         run: |

--- a/.github/workflows/osl-cicd-actions.yml
+++ b/.github/workflows/osl-cicd-actions.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
+          pip install -e .[full]
 
       - name: Run test suite
         run: |


### PR DESCRIPTION
Git workflow used python 3.10, which caused an issue with the tests. Now match the git workflow to the recommended version: 3.8.16.