### PR TITLE
Installation + Release Notes

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -26,7 +26,7 @@ copyright = '2023, OHBA Analysis Group'
 author = 'OHBA Analysis Group'
 
 # The full version, including alpha/beta/rc tags
-release = '0.7.0'
+release = '0.8.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/envs/linux-full-with-spyder.yml
+++ b/envs/linux-full-with-spyder.yml
@@ -24,7 +24,7 @@ dependencies:
   - tabulate==0.9.0
   - pyyaml==6.0.1
   - neurokit2==0.2.3
-  - jinja2==3.1.2
+  - jinja2==3.0.3
   - glmtools==0.2.1
   - numba==0.58.0
   - nilearn==0.10.2

--- a/envs/linux-full.yml
+++ b/envs/linux-full.yml
@@ -23,7 +23,7 @@ dependencies:
   - tabulate==0.9.0
   - pyyaml==6.0.1
   - neurokit2==0.2.3
-  - jinja2==3.1.2
+  - jinja2==3.0.3
   - glmtools==0.2.1
   - numba==0.58.0
   - nilearn==0.10.2

--- a/envs/linux-with-spyder.yml
+++ b/envs/linux-with-spyder.yml
@@ -24,7 +24,7 @@ dependencies:
   - tabulate==0.9.0
   - pyyaml==6.0.1
   - neurokit2==0.2.3
-  - jinja2==3.1.2
+  - jinja2==3.0.3
   - glmtools==0.2.1
   - numba==0.58.0
   - nilearn==0.10.2

--- a/envs/linux.yml
+++ b/envs/linux.yml
@@ -23,7 +23,7 @@ dependencies:
   - tabulate==0.9.0
   - pyyaml==6.0.1
   - neurokit2==0.2.3
-  - jinja2==3.1.2
+  - jinja2==3.0.3
   - glmtools==0.2.1
   - numba==0.58.0
   - nilearn==0.10.2

--- a/envs/mac-full.yml
+++ b/envs/mac-full.yml
@@ -25,7 +25,7 @@ dependencies:
   - tabulate==0.9.0
   - pyyaml==6.0.1
   - neurokit2==0.2.3
-  - jinja2==3.1.2
+  - jinja2==3.0.3
   - glmtools==0.2.1
   - numba==0.58.0
   - nilearn==0.10.2

--- a/envs/mac-with-spyder.yml
+++ b/envs/mac-with-spyder.yml
@@ -26,7 +26,7 @@ dependencies:
   - tabulate==0.9.0
   - pyyaml==6.0.1
   - neurokit2==0.2.3
-  - jinja2==3.1.2
+  - jinja2==3.0.3
   - glmtools==0.2.1
   - numba==0.58.0
   - nilearn==0.10.2

--- a/envs/mac.yml
+++ b/envs/mac.yml
@@ -25,7 +25,7 @@ dependencies:
   - tabulate==0.9.0
   - pyyaml==6.0.1
   - neurokit2==0.2.3
-  - jinja2==3.1.2
+  - jinja2==3.0.3
   - glmtools==0.2.1
   - numba==0.58.0
   - nilearn==0.10.2

--- a/envs/osl-workshop-23.yml
+++ b/envs/osl-workshop-23.yml
@@ -23,7 +23,7 @@ dependencies:
   - tabulate==0.9.0
   - pyyaml==6.0
   - neurokit2==0.2.3
-  - jinja2==3.1.2
+  - jinja2==3.0.3
   - glmtools==0.2.1
   - numba==0.56.4
   - nilearn==0.10.0

--- a/release_notes.md
+++ b/release_notes.md
@@ -55,6 +55,7 @@ You need to update the version number the the following files to version number 
 
 - `setup.py`
 - `osl/__init__.py`
+- `doc/source/conf.py`
 
 Don't forget to commit these changes before continuing.
 


### PR DESCRIPTION
Issues:
- The readthedocs website was showing the incorrect version, this is because the source code for the documentation was not updated.
- The installation instructions would install an older release of OSL (due to dependency version issues).

Changes:
- We update the version in the docs.
  - We added the file to the release notes to avoid this occurring again.
- Fixed the conda environemnts to make sure the latest OSL is installed when someone follows the official instructions.