### PR TITLE
Include READMEs in PyPI package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,9 @@ setup(name=name,
                             # Parcellation files
                             'source_recon/parcellation/files/*gz',
                             # Report templates
-                            'report/templates/*']},
+                            'report/templates/*',
+                            # READMEs
+                            '*/README.md']},
 
       command_options={
           'build_sphinx': {


### PR DESCRIPTION
Closes https://github.com/OHBA-analysis/osl/issues/329.

Previously the README.md files weren't included in the PyPI package. This caused an issue with installing the package via `pip` (where `osl` could not be imported). This PR resolve the issue.