### PR TITLE
Preproc updates

### DIFF
--- a/osl_ephys/preprocessing/batch.py
+++ b/osl_ephys/preprocessing/batch.py
@@ -908,6 +908,8 @@ def run_proc_chain(
                 dataset["raw"],
                 report_data_dir,
                 ica=dataset["ica"],
+                events=dataset["events"],
+                event_id=dataset["event_id"],
                 preproc_fif_filename=outnames["raw"],
                 logsdir=logsdir,
                 run_id=run_id,

--- a/osl_ephys/preprocessing/batch.py
+++ b/osl_ephys/preprocessing/batch.py
@@ -1162,6 +1162,7 @@ def run_proc_batch(
 
 
     # start group processing
+    custom_figures = None
     if config['group'] is not None:
         logger.info("Starting Group Processing")
         logger.info(
@@ -1191,11 +1192,12 @@ def run_proc_batch(
             dataset = func(dataset, userargs)
         outbase = os.path.join(outdir, "{ftype}.{fext}")
         outnames = write_dataset(dataset, outbase, '', ftype='', overwrite=overwrite, skip=skip_save)
+        custom_figures = dataset.get('fig', None)
 
     # rerun the summary report
     if gen_report:
         from ..report import preproc_report # avoids circular import
-        if preproc_report.gen_html_summary(reportdir, logsdir, custom_figures=dataset.get('fig', None)):
+        if preproc_report.gen_html_summary(reportdir, logsdir, custom_figures=custom_figures):
             logger.info("******************************" + "*" * len(str(reportdir)))
             logger.info(f"* REMEMBER TO CHECK REPORT: {reportdir} *")
             logger.info("******************************" + "*" * len(str(reportdir)))

--- a/osl_ephys/preprocessing/batch.py
+++ b/osl_ephys/preprocessing/batch.py
@@ -683,7 +683,7 @@ def plot_preproc_flowchart(
     for idx, stage in enumerate(stages):
         method, userargs = next(iter(stage.items()))
 
-        method = method.replace("_", "\_")
+        method = method.replace("_", r"\_")
         if method in ["input", "preproc", "group", "output"]:
             b = startbox
         else:
@@ -898,6 +898,12 @@ def run_proc_chain(
             from ..report import gen_html_data, gen_html_page  # avoids circular import
             logger.info("{0} : Generating Report".format(now))
             report_data_dir = validate_outdir(reportdir / Path(outnames["raw"]).stem.replace(f"_{ftype}", ""))
+            
+            if 'fig' in dataset and dataset['fig'] is not None and len(dataset['fig'])>0:
+                custom_figures = dataset['fig']
+            else:
+                custom_figures = None
+            
             gen_html_data(
                 dataset["raw"],
                 report_data_dir,
@@ -905,6 +911,7 @@ def run_proc_chain(
                 preproc_fif_filename=outnames["raw"],
                 logsdir=logsdir,
                 run_id=run_id,
+                custom_figures=custom_figures,
             )
             gen_html_page(reportdir)
 
@@ -1188,7 +1195,7 @@ def run_proc_batch(
     # rerun the summary report
     if gen_report:
         from ..report import preproc_report # avoids circular import
-        if preproc_report.gen_html_summary(reportdir, logsdir):
+        if preproc_report.gen_html_summary(reportdir, logsdir, custom_figures=dataset.get('fig', None)):
             logger.info("******************************" + "*" * len(str(reportdir)))
             logger.info(f"* REMEMBER TO CHECK REPORT: {reportdir} *")
             logger.info("******************************" + "*" * len(str(reportdir)))

--- a/osl_ephys/report/preproc_report.py
+++ b/osl_ephys/report/preproc_report.py
@@ -1041,7 +1041,7 @@ def plot_freqbands(raw, savebase=None):
             continue
 
         # Plot spectra
-        raw_zscore = deepcopy(raw).apply_function(lambda x: ((x - np.mean(x)) / np.std(x)))
+        raw_zscore = deepcopy(raw).apply_function(lambda x: ((x - np.mean(x)) / np.std(x)), picks=chan_inds)
         psd = raw_zscore.compute_psd(
             picks=chan_inds, 
             n_fft=int(raw.info['sfreq']*2),

--- a/osl_ephys/report/preproc_report.py
+++ b/osl_ephys/report/preproc_report.py
@@ -108,7 +108,7 @@ def get_header_id(raw):
 
 
 def gen_html_data(
-    raw, outdir, ica=None, preproc_fif_filename=None, logsdir=None, run_id=None, custom_figures=None
+    raw, outdir, ica=None, events=None, event_id=None, preproc_fif_filename=None, logsdir=None, run_id=None, custom_figures=None
 ):
     """Generate HTML web-report for an MNE data object.
 
@@ -120,6 +120,10 @@ def gen_html_data(
         Directory to write HTML data and plots to.
     ica : :py:class:`mne.preprocessing.ICA <mne.preprocessing.ICA>`
         ICA object.
+    events : array, shape (n_events, 3)
+        The events.
+    event_id : dict
+        The event IDs.
     preproc_fif_filename : str
         Filename of file output by preprocessing
     logsdir : str
@@ -239,6 +243,7 @@ def gen_html_data(
     data['plt_digitisation'] = plot_digitisation_2d(raw, savebase)
     data['plt_artefacts_eog'] = plot_eog_summary(raw, savebase)
     data['plt_artefacts_ecg'] = plot_ecg_summary(raw, savebase)
+    data['plt_events'] = plot_events(events, event_id, savebase)
     
     # add custom figures
     data['plt_custom_figures'] = plot_custom_figures(custom_figures, savebase)
@@ -1443,6 +1448,7 @@ def plot_summary_bad_chans(subject_data, reportdir):
     plt.close(fig)
     return f"summary/bad_chans.png"
 
+
 def plot_artefact_scan(raw, savebase=None):
     """Plot artefact scan.
     
@@ -1692,6 +1698,22 @@ def print_scan_summary(raw):
         s = 'Modality {0} - {1:02f}/{2} seconds rejected     ({3:02f}%)'
         print(s.format(modality, mod_dur, full_dur, pc))
         
+
+def plot_events(events, event_id, savebase):
+    if events is not None:
+        fig = mne.viz.plot_events(events, event_id=event_id, show=False)
+        figname = savebase.format('events')
+        fig.savefig(figname, dpi=150, transparent=True)
+        plt.close(fig)
+
+        # Return the filename
+        savebase = pathlib.Path(savebase)
+        filebase = savebase.parent.name + "/" + savebase.name
+        fpath = filebase.format('events')
+        return fpath
+    else:
+        return None
+
 
 def plot_custom_figures(custom_figures, savebase):
     plots = {}

--- a/osl_ephys/report/preproc_report.py
+++ b/osl_ephys/report/preproc_report.py
@@ -28,6 +28,8 @@ from mne.channels.channels import channel_type
 from matplotlib.lines import Line2D
 from matplotlib.patches import Rectangle
 from pathlib import Path
+from copy import deepcopy
+from glob import glob
 
 try:
     from scipy.ndimage import uniform_filter1d
@@ -106,7 +108,7 @@ def get_header_id(raw):
 
 
 def gen_html_data(
-    raw, outdir, ica=None, preproc_fif_filename=None, logsdir=None, run_id=None
+    raw, outdir, ica=None, preproc_fif_filename=None, logsdir=None, run_id=None, custom_figures=None
 ):
     """Generate HTML web-report for an MNE data object.
 
@@ -125,6 +127,9 @@ def gen_html_data(
         to be in reportdir.replace('report', 'logs')
     run_id : str
         Run ID.
+    custom_figures : dict
+        Dictionary of custom figures to include in the report. Keys should be the
+        figure names, and values should be the matplotlib figure objects.
     """
     
     # Silence all matplotlib show() warnings
@@ -234,6 +239,10 @@ def gen_html_data(
     data['plt_digitisation'] = plot_digitisation_2d(raw, savebase)
     data['plt_artefacts_eog'] = plot_eog_summary(raw, savebase)
     data['plt_artefacts_ecg'] = plot_ecg_summary(raw, savebase)
+    
+    # add custom figures
+    data['plt_custom_figures'] = plot_custom_figures(custom_figures, savebase)
+        
     #filenames = plot_artefact_scan(raw, savebase)
     #data.update(filenames)
 
@@ -291,7 +300,7 @@ def gen_html_data(
         pickle.dump(data, outfile)
 
 
-def gen_html_page(outdir, logsdir=None):
+def gen_html_page(outdir, logsdir=None, custom_figures=None):
     """Generate an HTML page from a report directory.
 
     Parameters
@@ -355,7 +364,7 @@ def gen_html_page(outdir, logsdir=None):
     return True
 
 
-def gen_html_summary(reportdir, logsdir=None):
+def gen_html_summary(reportdir, logsdir=None, custom_figures=None):
     """Generate an HTML summary from a report directory.
 
     Parameters
@@ -395,8 +404,15 @@ def gen_html_summary(reportdir, logsdir=None):
 
     # Create plots
     os.makedirs(f"{reportdir}/summary", exist_ok=True)
-
     data["plt_config"] = subject_data[0]["plt_config"]
+    existing_figs = {ig.split('/')[-1].split('custom_')[1].split('.png')[0]: ig.replace(str(reportdir) + '/', '') for ig in glob(f"{reportdir}/summary/*.png")}
+    data['plt_custom_figures'] = plot_custom_figures(custom_figures, f"{reportdir}/summary/{{}}.png")
+    if len(existing_figs)>0:
+       if data['plt_custom_figures'] is None:
+           data['plt_custom_figures'] = existing_figs
+       else:
+           data['plt_custom_figures'] |= existing_figs
+
     if "extra_funcs" in subject_data[0]:
         data["extra_funcs"] = subject_data[0]["extra_funcs"]
     data['tbl'] = gen_summary_data(subject_data)
@@ -1020,7 +1036,8 @@ def plot_freqbands(raw, savebase=None):
             continue
 
         # Plot spectra
-        psd = raw.compute_psd(
+        raw_zscore = deepcopy(raw).apply_function(lambda x: ((x - np.mean(x)) / np.std(x)))
+        psd = raw_zscore.compute_psd(
             picks=chan_inds, 
             n_fft=int(raw.info['sfreq']*2),
             verbose=0)
@@ -1033,10 +1050,10 @@ def plot_freqbands(raw, savebase=None):
         for ifrq, (f1, f2) in enumerate(freq_bands):
             inds = np.logical_and(psd.freqs>f1, psd.freqs<=(f2))
             p = psd._data[:, inds].mean(axis=1)
-            if is_parc: # normalize because nilearn doesn't plot small values
-                plot_source_topo(p/p.std(), axis=iax[ifrq], cmap='Reds') 
+            if is_parc: # normalize because nilearwn doesn't plot small values
+                plot_source_topo(p/p.std(), axis=iax[ifrq], cmap='hot') 
             else:
-                mne.viz.plot_topomap(p, psd.info, axes=iax[ifrq])
+                mne.viz.plot_topomap(p, psd.info, axes=iax[ifrq], cmap='hot')
             if row==0:
                 iax[ifrq].set_title(f"{freq_band_names[ifrq]}\n({f1}-{f2} Hz)")
             if ifrq==0:
@@ -1050,7 +1067,11 @@ def plot_freqbands(raw, savebase=None):
         figname = savebase.format('freqbands')
         fig.savefig(figname, dpi=150, transparent=True)
         plt.close(fig)
-        return figname
+        
+        savebase = pathlib.Path(savebase)
+        filebase = savebase.parent.name + "/" + savebase.name
+        fpath = filebase.format('freqbands')
+        return fpath
     else:
         return None
 
@@ -1670,3 +1691,22 @@ def print_scan_summary(raw):
         pc = (mod_dur / full_dur) * 100
         s = 'Modality {0} - {1:02f}/{2} seconds rejected     ({3:02f}%)'
         print(s.format(modality, mod_dur, full_dur, pc))
+        
+
+def plot_custom_figures(custom_figures, savebase):
+    plots = {}
+    if custom_figures is not None and type(custom_figures)==dict:
+        for key in custom_figures.keys():
+            if type(custom_figures[key])==plt.Figure:
+                figname = savebase.format(f'custom_{key}')
+                custom_figures[key].savefig(figname, dpi=150, transparent=True)
+                plt.close(custom_figures[key])
+                # Return the filename
+                savebase_path = pathlib.Path(savebase)
+                filebase = savebase_path.parent.name + "/" + savebase_path.name
+                plots[key] = filebase.format(f'custom_{key}')
+            else:
+                log_or_print(f"Custom figure {key} is not a matplotlib figure. Skipping.")
+    if len(plots)==0:
+        plots = None
+    return plots

--- a/osl_ephys/report/templates/raw_subject_panel.html
+++ b/osl_ephys/report/templates/raw_subject_panel.html
@@ -3,7 +3,7 @@
     <div>
       <h3>{{ data.fif_id }} &ensp; ({{ data.num }} of {{ data.total }})</h3>
     </div>
-  
+    
     <div class="flex-container" style="display: flex">
   
     <div class="flex-child" style="flex: 1">
@@ -22,13 +22,24 @@
           {% if data.log is defined %}
               <button class="button1" onclick="openTab(event, '{{ data.fif_id }}_logs', this.id)">Logs</button>
           {% endif %}
+
+          {# --- Custom figures: create a tab button for each key --- #}
+          {% if data.plt_custom_figures is defined and data.plt_custom_figures %}
+            {% for key, val in data.plt_custom_figures.items() %}
+                {# create a safe id by replacing spaces and slashes #}
+                {% set safe_key = key|replace(' ', '_')|replace('/', '_') %}
+                <button class="button1" id="{{ data.fif_id }}_btn_custom_{{ safe_key }}"
+                        onclick="openTab(event, '{{ data.fif_id }}_custom_{{ safe_key }}', this.id)">
+                    {{ key }}
+                </button>
+            {% endfor %}
+          {% endif %}
   
       </div>
     </div>
   
     <div class="flex-child" style="flex: 5; padding-left: 25px">
-  
-      <div class="tabpage" style='width: 100%' id={{ data.fif_id }}_info>
+      <div class="tabpage" style='width: 100%' id="{{ data.fif_id }}_info">
           <div>
               <b>Original file:</b> {{ data.filename }}</br>
               {% if data.preproc_fif_filename != None %}
@@ -55,7 +66,7 @@
           </div>
       </div>
       
-      <div class="tabpage" style="width: 100%; display: none" id={{ data.fif_id }}_timeseries>
+      <div class="tabpage" style="width: 100%; display: none" id="{{ data.fif_id }}_timeseries">
           <div style="width: 100%">
               <h4>Raw data
                   <span style="margin-right: 10px;"></span>
@@ -124,7 +135,7 @@
           {% endif %}
       </div>
           
-      <div class="tabpage" style="width: 100%; display: none" id={{ data.fif_id }}_channels>
+      <div class="tabpage" style="width: 100%; display: none" id="{{ data.fif_id }}_channels">
           <div style="width: 75%; margin:0 auto">
               <h4>Distribution of Per-Sensor Variance
                   <span style="margin-right: 10px;"></span>
@@ -154,7 +165,7 @@
           </div>
       </div>
           
-      <div class="tabpage" style="width: 100%; display: none" id={{ data.fif_id }}_spectra>
+      <div class="tabpage" style="width: 100%; display: none" id="{{ data.fif_id }}_spectra">
           <div style="width: 100%; display: table; table-layout: fixed;">
               <div style="display: table-row; height: 100px;">
                   <div class='figbox' style="display: table-cell; width: 50%; vertical-align: top;">
@@ -191,7 +202,7 @@
           </div>
       </div>
       
-      <div class="tabpage" style="width: 100%; display: none" id={{ data.fif_id }}_digitisation>
+      <div class="tabpage" style="width: 100%; display: none" id="{{ data.fif_id }}_digitisation">
           <div style="width: 100%">
               <h4>Digitisation and Headshape
                   <span style="margin-right: 10px;"></span>
@@ -205,7 +216,7 @@
       </div>
   
       {% if data.plt_ica is defined %}
-          <div class="tabpage" style="width: 100%; display: none" id={{ data.fif_id }}_ica>
+          <div class="tabpage" style="width: 100%; display: none" id="{{ data.fif_id }}_ica">
               <div style="width: 100%">
                   <h4>ICA
                       <span style="margin-right: 10px;"></span>
@@ -218,9 +229,24 @@
               </div>
           </div>
       {% endif %}
+
+      {# --- Custom figure tab pages --- #}
+      {% if data.plt_custom_figures is defined and data.plt_custom_figures %}
+            {% for key, val in data.plt_custom_figures.items() %}
+                {% set safe_key = key|replace(' ', '_')|replace('/', '_') %}
+                <div class="tabpage" style="width: 100%; display: none" id="{{ data.fif_id }}_custom_{{ safe_key }}">
+                    <div style="width: 100%">
+                        <h4>{{ key }}</h4>
+                        {# assume val is a URL/path to the figure (same pattern as other plt_* fields) #}
+                        <img src="{{ val }}" alt="{{ key }}" style="max-width: 100%;"/>
+                    </div>
+                </div>
+            {% endfor %}
+      {% endif %}
+
   
       {% if data.log is defined %}
-          <div class="tabpage" style="width: 100%; display: none" id={{ data.fif_id }}_logs>               
+          <div class="tabpage" style="width: 100%; display: none" id="{{ data.fif_id }}_logs">               
               <h4>Preprocessing Log</h4>
               <textarea id="log" rows="20" style="width: 80%;" readonly>{{ data.log }}</textarea>
               {% if data.errlog is defined %}
@@ -231,7 +257,7 @@
       {% endif %}
   
       {% if data.maxlog_autobad is defined or data.maxlog_sss is defined or data.maxlog_trans is defined %}
-          <div class="tabpage" style="width: 100%; display: none" id={{ data.fif_id }}_maxfilt>               
+          <div class="tabpage" style="width: 100%; display: none" id="{{ data.fif_id }}_maxfilt">               
               <h3>Maxfilter Logs</h3>
               {% if data.maxlog_autobad is defined %}
                   <h4>Autobad</h4>
@@ -250,41 +276,288 @@
       </div>
     </div>
   </div>
-  
-  <script>
-  
-  function openTab(event, figTag, button) {
-      // Get all elements with class="tabpage" and hide them
-      tabpage = document.getElementsByClassName("tabpage");
-      for (i = 0; i < tabpage.length; i++) {
-          tabpage[i].style.display = "none";
-      }
-      // Show the current tab
-      document.getElementById(figTag).style.display = "block";
-      if (figTag.includes('info')) {
-          currentButton = 0;
-      }
-      if (figTag.includes('timeseries')) {
-          currentButton = 1;
-      }
-      if (figTag.includes('channels')) {
-          currentButton = 2;
-      }
-      if (figTag.includes('spectra')) {
-          currentButton = 3;
-      }
-      if (figTag.includes('digitisation')) {
-          currentButton = 4;
-      }
-      if (figTag.includes('ica')) {
-          currentButton = 5;
-      }
-      if (figTag.includes('logs')) {
-          currentButton = 6;
-      }
-      if (figTag.includes('maxfilt')) {
-          currentButton = 7;
-      }
+
+
+<script>
+(function () {
+  // Globals
+  window.currentButton = typeof window.currentButton === 'number' ? window.currentButton : 0;
+  window.currentFifId = window.currentFifId || null;
+  let suppressTabNav = false; // when true, ignore arrow/tab programmatic changes for a moment
+
+  // Helpers
+  function findVisibleFif() {
+    const fifEls = Array.from(document.getElementsByClassName('fif'));
+    for (const el of fifEls) {
+      if (el.offsetParent !== null) return el;
+    }
+    return fifEls[0] || null;
   }
-  
-  </script>
+
+  function getButtonsForFif(fifEl) {
+    if (!fifEl) fifEl = findVisibleFif();
+    if (!fifEl) return [];
+    return Array.from(fifEl.querySelectorAll('.button1'));
+  }
+
+  function parseFigTagFromOnclick(onclickText) {
+    if (!onclickText) return null;
+    const m = onclickText.match(/openTab\([^,]*,\s*(['"])(.*?)\1/);
+    return m ? m[2] : null;
+  }
+
+  function getActiveIndex(buttons) {
+    if (!buttons || buttons.length === 0) return -1;
+    const idx = buttons.findIndex(b => b.classList.contains('active'));
+    if (idx !== -1) return idx;
+    // fallback: deduce from visible tabpage
+    for (let i = 0; i < buttons.length; i++) {
+      const onclick = buttons[i].getAttribute('onclick') || '';
+      const tag = parseFigTagFromOnclick(onclick);
+      if (tag) {
+        const el = document.getElementById(tag);
+        if (el && el.style && el.style.display !== 'none') return i;
+      }
+    }
+    return 0;
+  }
+
+function restoreActiveTabForFif(fifEl) {
+  if (!fifEl) fifEl = findVisibleFif();
+  if (!fifEl) return;
+
+  // try stored data-active-tab first
+  const stored = fifEl.dataset && fifEl.dataset.activeTab ? fifEl.dataset.activeTab : null;
+
+  // Find currently visible tag in this panel (if any)
+  const buttons = getButtonsForFif(fifEl);
+  let currentVisibleTag = null;
+  for (let i = 0; i < buttons.length; i++) {
+    const onclick = buttons[i].getAttribute('onclick') || '';
+    const tag = parseFigTagFromOnclick(onclick);
+    if (tag) {
+      const el = document.getElementById(tag);
+      if (el && el.style && el.style.display !== 'none') {
+        currentVisibleTag = tag;
+        break;
+      }
+    }
+  }
+
+  // If stored tab matches what's already visible, do nothing.
+  if (stored && stored === currentVisibleTag) {
+    // still sync numeric index to be safe
+    const idx = getActiveIndex(buttons);
+    window.currentButton = idx === -1 ? 0 : idx;
+    window.currentFifId = fifEl.id || null;
+    return;
+  }
+
+  // Decide fallback target if nothing stored
+  let targetTag = stored;
+  if (!targetTag) {
+    // fallback to first visible or first button tag
+    for (let i = 0; i < buttons.length; i++) {
+      const onclick = buttons[i].getAttribute('onclick') || '';
+      const tag = parseFigTagFromOnclick(onclick);
+      if (tag) {
+        const el = document.getElementById(tag);
+        if (el && el.style && el.style.display !== 'none') { targetTag = tag; break; }
+      }
+    }
+    if (!targetTag && buttons.length > 0) {
+      const onclick = buttons[0].getAttribute('onclick') || '';
+      targetTag = parseFigTagFromOnclick(onclick);
+    }
+  }
+
+  if (targetTag) {
+    // prevent other handlers from reacting while we restore
+    setSuppressNavShort();
+    // openTab will set active class and numeric index
+    openTab(null, targetTag, buttons.length > 0 ? buttons[0].id : null);
+  }
+}
+
+
+  // Core openTab: show tabpage, set active button, persist per-fif active tag
+  window.openTab = function (event, figTag, buttonId) {
+    // If called without figTag -> nothing to do
+    if (!figTag) return;
+
+    // hide all tabpages
+    const tabpages = Array.from(document.getElementsByClassName('tabpage'));
+    tabpages.forEach(tp => tp.style.display = 'none');
+
+    // show requested tabpage
+    const tgt = document.getElementById(figTag);
+    if (tgt) {
+      tgt.style.display = 'block';
+    } else {
+      console.warn('Tab target not found:', figTag);
+    }
+
+    // Determine the .fif container for this tab
+    let fifEl = null;
+    if (buttonId) {
+      const btnEl = document.getElementById(buttonId);
+      if (btnEl) fifEl = btnEl.closest('.fif');
+    }
+    if (!fifEl && tgt) fifEl = tgt.closest('.fif');
+    if (!fifEl) fifEl = findVisibleFif();
+
+    // Update buttons active state within that panel
+    const buttons = getButtonsForFif(fifEl);
+    buttons.forEach(b => b.classList.remove('active'));
+
+    // find index of the clicked button among these buttons
+    let idx = -1;
+    if (buttonId) idx = buttons.findIndex(b => b.id === buttonId);
+    if (idx === -1 && event && event.currentTarget) idx = buttons.indexOf(event.currentTarget);
+
+    if (idx === -1 && figTag) {
+      for (let i = 0; i < buttons.length; i++) {
+        const onclick = buttons[i].getAttribute('onclick') || '';
+        const tag = parseFigTagFromOnclick(onclick);
+        if (tag === figTag) { idx = i; break; }
+      }
+    }
+
+    if (idx === -1) idx = buttons.length > 0 ? 0 : -1;
+    if (idx !== -1 && buttons[idx]) buttons[idx].classList.add('active');
+
+    // persist the exact tag for this fif so we can restore it when we revisit this file
+    if (fifEl) {
+      try {
+        fifEl.dataset.activeTab = figTag;
+      } catch (e) {
+        // ignore if dataset unsupported for some reason
+      }
+      window.currentFifId = fifEl.id || null;
+    }
+
+    // store numeric index as well (some legacy code may expect it)
+    window.currentButton = idx === -1 ? 0 : idx;
+  };
+
+  // Restore per-panel active tab when panel becomes visible
+  function restoreActiveTabForFif(fifEl) {
+    if (!fifEl) fifEl = findVisibleFif();
+    if (!fifEl) return;
+
+    // try stored data-active-tab first
+    const stored = fifEl.dataset && fifEl.dataset.activeTab ? fifEl.dataset.activeTab : null;
+
+    // else fall back to first button/Info
+    const buttons = getButtonsForFif(fifEl);
+    let targetTag = stored;
+    if (!targetTag) {
+      // prefer any currently visible tabpage in this panel
+      for (let i = 0; i < buttons.length; i++) {
+        const onclick = buttons[i].getAttribute('onclick') || '';
+        const tag = parseFigTagFromOnclick(onclick);
+        if (tag) {
+          const el = document.getElementById(tag);
+          if (el && el.style && el.style.display !== 'none') { targetTag = tag; break; }
+        }
+      }
+      // fallback to first button's tag
+      if (!targetTag && buttons.length > 0) {
+        const onclick = buttons[0].getAttribute('onclick') || '';
+        targetTag = parseFigTagFromOnclick(onclick);
+      }
+    }
+
+    if (targetTag) {
+      // prevent other handlers from reacting while we restore
+      setSuppressNavShort();
+      openTab(null, targetTag, buttons.length > 0 ? buttons[0].id : null); // openTab will resolve correct button
+    }
+  }
+
+  // Arrow navigation: compute active index live, then call openTab for exact tag.
+  window.gotoNextTab = function () {
+    if (suppressTabNav) return;
+    const fif = findVisibleFif();
+    const buttons = getButtonsForFif(fif);
+    if (!buttons || buttons.length === 0) return;
+    const active = getActiveIndex(buttons);
+    const next = Math.min(buttons.length - 1, (active === -1 ? 0 : active) + 1);
+    const onclick = buttons[next].getAttribute('onclick') || '';
+    const tag = parseFigTagFromOnclick(onclick);
+    // suppress briefly before we open (prevents race if file switch also happens)
+    setSuppressNavShort();
+    openTab(null, tag || null, buttons[next].id);
+  };
+
+  window.gotoPrevTab = function () {
+    if (suppressTabNav) return;
+    const fif = findVisibleFif();
+    const buttons = getButtonsForFif(fif);
+    if (!buttons || buttons.length === 0) return;
+    const active = getActiveIndex(buttons);
+    const prev = Math.max(0, (active === -1 ? 0 : active) - 1);
+    const onclick = buttons[prev].getAttribute('onclick') || '';
+    const tag = parseFigTagFromOnclick(onclick);
+    setSuppressNavShort();
+    openTab(null, tag || null, buttons[prev].id);
+  };
+
+  // keyboard binding
+  document.addEventListener('keydown', function (e) {
+    const activeEl = document.activeElement;
+    if (activeEl && (activeEl.tagName === 'INPUT' || activeEl.tagName === 'TEXTAREA' || activeEl.isContentEditable)) return;
+    if (e.key === 'ArrowRight') {
+      window.gotoNextTab();
+      e.preventDefault();
+    } else if (e.key === 'ArrowLeft') {
+      window.gotoPrevTab();
+      e.preventDefault();
+    }
+  });
+
+  // MutationObserver: detect visible .fif change. When that happens, restore that panel's saved tab.
+  let lastVisibleFifId = null;
+  let moTimer = null;
+  const mo = new MutationObserver(function () {
+    if (moTimer) clearTimeout(moTimer);
+    moTimer = setTimeout(function () {
+      const vis = findVisibleFif();
+      const visId = vis ? vis.id : null;
+      if (visId !== lastVisibleFifId) {
+        // visible panel changed
+        lastVisibleFifId = visId;
+        // prevent immediate key handlers causing races
+        setSuppressNavShort();
+        // restore that panel's saved tab (this calls openTab once)
+        restoreActiveTabForFif(vis);
+      } else {
+        // same panel — just sync numeric index
+        const fif = vis;
+        if (fif) {
+          const idx = getActiveIndex(getButtonsForFif(fif));
+          window.currentButton = idx === -1 ? 0 : idx;
+          window.currentFifId = fif.id || null;
+        }
+      }
+    }, 30);
+  });
+  mo.observe(document.body, { attributes: true, childList: true, subtree: true, attributeFilter: ['style', 'class'] });
+
+  // initial restore on load
+  document.addEventListener('DOMContentLoaded', function () {
+    const vis = findVisibleFif();
+    lastVisibleFifId = vis ? vis.id : null;
+    restoreActiveTabForFif(vis);
+  });
+
+})();
+</script>
+
+
+<style>
+.button1.active {
+    background-color: lightgreen;
+    border-bottom: 2px solid #2e8b57; /* darker green border for contrast */
+}
+</style>

--- a/osl_ephys/report/templates/raw_subject_panel.html
+++ b/osl_ephys/report/templates/raw_subject_panel.html
@@ -16,6 +16,9 @@
           <button class="button1" onclick="openTab(event, '{{ data.fif_id }}_channels', this.id)">Channels</button>
           <button class="button1" onclick="openTab(event, '{{ data.fif_id }}_spectra', this.id)">Power Spectra</button>
           <button class="button1" onclick="openTab(event, '{{ data.fif_id }}_digitisation', this.id)">Digitisation</button>
+          {% if data.plt_events is defined %}
+              <button class="button1" onclick="openTab(event, '{{ data.fif_id }}_events', this.id)">Events</button>
+          {% endif %}
           {% if data.plt_ica is defined %}
               <button class="button1" onclick="openTab(event, '{{ data.fif_id }}_ica', this.id)">ICA</button>
           {% endif %}
@@ -214,7 +217,22 @@
               <img src="{{ data.plt_digitisation }}" alt="" style='max-width: 100%'/>
           </div>
       </div>
-  
+    
+      {% if data.plt_events is defined %}
+      <div class="tabpage" style="width: 100%; display: none" id="{{ data.fif_id }}_events">
+          <div style="width: 100%">
+              <h4>Events
+                  <span style="margin-right: 10px;"></span>
+                  <button style="cursor: help; border: 1px solid; background-color: lightblue; color: black; padding: 2px 5px; font-size: 12px;" 
+                          title="Do the events look sensible? i.e., are the numbers and timings the way you would?">
+                      ?
+                  </button>
+              </h4>
+              <img src="{{ data.plt_events }}" alt="" style='max-width: 100%'/>
+          </div>
+      </div>
+      {% endif %}
+
       {% if data.plt_ica is defined %}
           <div class="tabpage" style="width: 100%; display: none" id="{{ data.fif_id }}_ica">
               <div style="width: 100%">

--- a/osl_ephys/report/templates/raw_summary_panel.html
+++ b/osl_ephys/report/templates/raw_summary_panel.html
@@ -1,41 +1,59 @@
 <div style='max-width: 90%; margin: auto; margin-bottom: 40px; background: #f6f6f6; box-shadow: 10px 10px 5px grey; padding: 25px 25px 25px 0px;'>
-    <div class="flex-container" style="display: flex">
-  
+  <div class="flex-container" style="display: flex">
+
     <div class="flex-child" style="flex: 1">
       <div class="tab" style="display: grid">
-          <button class="button1" onclick="openTab(event, 'config', this.id)" style="border-top-style: solid">Config</button>
-          <button class="button1" onclick="openTab(event, 'tbl', this.id)" style="border-top-style: solid">Preproc Summary</button>
+          <!-- give these explicit ids so JS can reference them -->
+          <button class="button1" id="summary_btn_config"
+                  onclick="openTab(event, 'config', this.id)" style="border-top-style: solid">Config</button>
+          <button class="button1" id="summary_btn_tbl"
+                  onclick="openTab(event, 'tbl', this.id)">Preproc Summary</button>
+
+        {# --- Custom figures: create a tab button for each key --- #}
+          {% if data.plt_custom_figures is defined and data.plt_custom_figures %}
+            {% for key, val in data.plt_custom_figures.items() %}
+                {% set safe_key = key|replace(' ', '_')|replace('/', '_') %}
+                <button class="button1" id="summary_btn_custom_{{ safe_key }}"
+                        onclick="openTab(event, 'summary_custom_{{ safe_key }}', this.id)">
+                    {{ key }}
+                </button>
+            {% endfor %}
+          {% endif %}
+
           {% if data.batchlog is defined %}
-              <button class="button1" onclick="openTab(event, 'batchlog', this.id)" style="border-top-style: solid">Batch Log</button>
+              <button class="button1" id="summary_btn_batchlog"
+                      onclick="openTab(event, 'batchlog', this.id)">Batch Log</button>
           {% endif %}
           {% if data.errlog is defined %}
-              <button class="button1" onclick="openTab(event, 'errlog', this.id)" style="border-top-style: solid">Error Logs</button>
+              <button class="button1" id="summary_btn_errlog"
+                      onclick="openTab(event, 'errlog', this.id)">Error Logs</button>
           {% endif %}
+
       </div>
     </div>
-  
+
     <div class="flex-child" style="flex: 5; padding-left: 25px">
-  
+
       <div class="tabpage" style='width: 100%' id='config'>
           <h3>Config</h3>
           <img src="{{ data.plt_config }}" alt="" style='max-width: 60%'/>
           {% if data.extra_funcs is defined %}
               <h3>Extra functions
                   <span style="margin-right: 10px;"></span>
-                  <button style="cursor: help; border: 1px solid; background-color: lightblue; color: black; padding: 2px 5px; font-size: 12px;" 
+                  <button style="cursor: help; border: 1px solid; background-color: lightblue; color: black; padding: 2px 5px; font-size: 12px;"
                           title="This is the list of extra functions that were used in the preprocessing.">
                       ?
                   </button>
               </h3>
-              <textarea id="log" rows="20" style="width: 80%;" readonly>{{ data.extra_funcs }}</textarea>
+              <textarea id="log_extra_funcs" rows="20" style="width: 80%;" readonly>{{ data.extra_funcs }}</textarea>
           {% endif %}
       </div>
-  
-      <div class="tabpage" style='width: 90%' id='tbl'>
+
+      <div class="tabpage" style='width: 90%; display: none' id='tbl'>
           <h3>Preproc Summary
               <span style="margin-right: 10px;"></span>
-              <button style="cursor: help; border: 1px solid; background-color: lightblue; color: black; padding: 2px 5px; font-size: 12px;" 
-                      title="This table is interactive and can be used to guide quality assurance. For example, sort the table by different columns. Which recordings have the most bad channels? Which recordings have the most bad trials? Which recordings have no bad ICA components? These subjects are good candidates for further inspection in the subject report.">
+              <button style="cursor: help; border: 1px solid; background-color: lightblue; color: black; padding: 2px 5px; font-size: 12px;"
+                      title="This table is interactive and can be used to guide quality assurance.">
                   ?
               </button>
           </h3>
@@ -43,59 +61,180 @@
           {{ data.tbl | safe }}
           </div>
       </div>
-  
+
+      {# --- Custom figure tab pages --- #}
+      {% if data.plt_custom_figures is defined and data.plt_custom_figures %}
+            {% for key, val in data.plt_custom_figures.items() %}
+                {% set safe_key = key|replace(' ', '_')|replace('/', '_') %}
+                <div class="tabpage" style="width: 100%; display: none" id="summary_custom_{{ safe_key }}">
+                    <div style="width: 100%">
+                        <h4>{{ key }}</h4>
+                        <img src="{{ val }}" alt="{{ key }}" style="max-width: 100%;"/>
+                    </div>
+                </div>
+            {% endfor %}
+      {% endif %}
+
       {% if data.batchlog is defined %}
-      <div class="tabpage" style="width: 100%; display: none" id=batchlog>               
+      <div class="tabpage" style="width: 100%; display: none" id="batchlog">
           <h4>Batch Log</h4>
-          <textarea id="batchlog" rows="20" style="width: 80%;" readonly>{{ data.batchlog }}</textarea>
+          <textarea id="batchlog_txt" rows="20" style="width: 80%;" readonly>{{ data.batchlog }}</textarea>
       </div>
       {% endif %}
-  
+
       {% if data.errlog is defined %}
-      <div class="tabpage" style="width: 100%; display: none" id=errlog>               
+      <div class="tabpage" style="width: 100%; display: none" id="errlog">
           <h4>Error Logs</h4>
               {% for key, value in data.errlog.items() %}
                   <h5>{{ key }}</h5>
-                  <textarea id="{{ key }}" rows="20" style="width: 80%;" readonly>{{ value }}</textarea>
+                  <textarea id="errlog_{{ loop.index }}" rows="20" style="width: 80%;" readonly>{{ value }}</textarea>
               {% endfor %}
       </div>
       {% endif %}
-  
-      </div>
+
     </div>
   </div>
-  
-  <script>
-  
-  function openTab(event, figTag, button) {
-      // Get all elements with class="tabpage" and hide them
-      tabpage = document.getElementsByClassName("tabpage");
-      for (i = 0; i < tabpage.length; i++) {
-          tabpage[i].style.display = "none";
-      }
-      // Show the current tab
-      document.getElementById(figTag).style.display = "block";
-      if (figTag.includes('config')) {
-          currentButton = 0;
-      }
-      if (figTag.includes('tbl')) {
-          currentButton = 1;
-      }
-      if (figTag.includes('batchlog')) {
-          currentButton = 2;
-      }
-      if (figTag.includes('errlog')) {
-          currentButton = 3;
-      }
+</div>
+
+<style>
+/* change active tab highlight to lightgreen */
+.button1.active {
+    background-color: lightgreen;
+    border-bottom: 2px solid #2e8b57; /* darker green border for contrast */
+}
+</style>
+
+<script>
+(function () {
+  // locate the summary tab column (first .tab in this summary block)
+  const summaryTabColumn = document.querySelector('div.tab');
+  if (!summaryTabColumn) return;
+
+  // the surrounding .flex-container holds the tab pages we want to control
+  const panel = summaryTabColumn.closest('.flex-container');
+  const summaryButtons = Array.from(summaryTabColumn.querySelectorAll('.button1'));
+
+  // helper: extract target id from an onclick string
+  function extractTargetFromOnclick(onclick) {
+    const m = (onclick || '').match(/openTab\([^,]*,\s*['"]([^'"]+)['"]/);
+    return m ? m[1] : null;
   }
-  
-  document.addEventListener('DOMContentLoaded', function() {
-      $('#preproc_tbl').DataTable();
+
+  // stash each button's target into dataset.target and remove inline onclick
+  summaryButtons.forEach((btn) => {
+    const onclick = btn.getAttribute('onclick');
+    const target = extractTargetFromOnclick(onclick);
+    if (target) btn.dataset.target = target;
+    // remove inline onclick to avoid unpredictable double-calls
+    btn.removeAttribute('onclick');
+  });
+
+  // clamp helper
+  function clamp(n, a, b) { return Math.max(a, Math.min(b, n)); }
+
+  // activate a button (index): set .active, focus, persist index, and open content
+  function activateIndex(idx, { focus = true, callOpen = true } = {}) {
+    if (!summaryButtons.length) return;
+    idx = clamp(idx, 0, summaryButtons.length - 1);
+    const btn = summaryButtons[idx];
+
+    // visual
+    summaryButtons.forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    if (focus) btn.focus();
+    summaryTabColumn.dataset.currentIndex = idx;
+
+    // open content: prefer global openTab if present; fallback to scoped show/hide
+    const target = btn.dataset.target || null;
+    if (!target) return;
+    if (callOpen && typeof window.openTab === 'function') {
+      // This uses the project's openTab to keep behaviour consistent
+      try {
+        window.openTab(null, target, btn.id);
+      } catch (e) {
+        // fallback to manual below if openTab throws
+        manualShow(target);
+      }
+    } else if (callOpen) {
+      manualShow(target);
+    }
+  }
+
+  // fallback manual show/hide for tabpages scoped to this summary panel
+  function manualShow(targetId) {
+    if (!panel) return;
+    const pages = Array.from(panel.querySelectorAll('.tabpage'));
+    pages.forEach(p => p.style.display = 'none');
+    const tgt = document.getElementById(targetId);
+    if (tgt) tgt.style.display = 'block';
+  }
+
+  // wire click handlers (now we control activation centrally)
+  summaryButtons.forEach((btn, i) => {
+    btn.addEventListener('click', function (ev) {
+      ev.preventDefault();
+      activateIndex(i, { focus: true, callOpen: true });
     });
-  
-  </script>
-  
-  
-  <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.24/css/jquery.dataTables.css">
-  <script type="text/javascript" charset="utf8" src="https://code.jquery.com/jquery-3.5.1.js"></script>
-  <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.24/js/jquery.dataTables.js"></script>
+  });
+
+  // set initial tab: prefer 'config' if present, otherwise first button
+  function showInitial() {
+    let startIdx = summaryButtons.findIndex(b => b.dataset.target === 'config');
+    if (startIdx === -1) startIdx = 0;
+    activateIndex(startIdx, { focus: true, callOpen: true });
+  }
+
+  // keyboard: Up/Down to move AND activate; Enter will also activate focused button
+  document.addEventListener('keydown', function (e) {
+    // ignore when typing in inputs/textareas
+    const ae = document.activeElement;
+    if (ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA' || ae.isContentEditable)) return;
+
+    if (!summaryButtons.length) return;
+
+    let currentIndex = parseInt(summaryTabColumn.dataset.currentIndex || -1, 10);
+    if (isNaN(currentIndex) || currentIndex < 0) {
+      currentIndex = summaryButtons.findIndex(b => b.classList.contains('active'));
+      if (currentIndex === -1) currentIndex = 0;
+    }
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      const next = clamp(currentIndex + 1, 0, summaryButtons.length - 1);
+      activateIndex(next, { focus: true, callOpen: true });
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      const prev = clamp(currentIndex - 1, 0, summaryButtons.length - 1);
+      activateIndex(prev, { focus: true, callOpen: true });
+    } else if (e.key === 'Enter') {
+      // activate focused button (if it's one of our summary buttons)
+      const focused = document.activeElement;
+      const idx = summaryButtons.indexOf(focused);
+      if (idx !== -1) {
+        e.preventDefault();
+        activateIndex(idx, { focus: true, callOpen: true });
+      }
+    }
+  });
+
+  // init on DOMContentLoaded (and immediately if DOM already ready)
+  document.addEventListener('DOMContentLoaded', showInitial);
+  if (document.readyState === 'interactive' || document.readyState === 'complete') showInitial();
+
+})(); // IIFE
+</script>
+
+
+<!-- DataTables assets (unchanged) -->
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.24/css/jquery.dataTables.css">
+<script type="text/javascript" charset="utf8" src="https://code.jquery.com/jquery-3.5.1.js"></script>
+<script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.24/js/jquery.dataTables.js"></script>
+
+<script>
+  // init datatable if table id present
+  document.addEventListener('DOMContentLoaded', function() {
+    if (document.getElementById('preproc_tbl')) {
+      try { $('#preproc_tbl').DataTable(); } catch(e) { console.warn('DataTable init failed', e); }
+    }
+  });
+</script>

--- a/osl_ephys/report/templates/src_subject_panel.html
+++ b/osl_ephys/report/templates/src_subject_panel.html
@@ -1,12 +1,11 @@
-<div class="fif" style='max-width: 90%; margin: auto; margin-bottom: 40px; background: #f6f6f6; box-shadow: 10px 10px 5px grey; padding: 25px 25px 25px 0px;' id="{{ data.fif_id }}">
+<div class="fif" style="max-width: 90%; margin: auto; margin-bottom: 40px; background: #f6f6f6; box-shadow: 10px 10px 5px grey; padding: 25px 25px 25px 0px; display: inline-block; vertical-align: top;" id="{{ data.fif_id }}">
 
-    <div>
-      <h3>{{ data.fif_id }} &ensp; ({{ data.num }} of {{ data.total }})</h3>
-    </div>
-  
-    <div class="flex-container" style="display: flex">
-  
-    <div class="flex-child" style="flex: 1">
+  <div>
+    <h3>{{ data.fif_id }} &ensp; ({{ data.num }} of {{ data.total }})</h3>
+  </div>
+
+  <div style="display: table; width: 100%">
+    <div style="display: table-cell; width: 20%; vertical-align: top">
       <div class="tab" style="display: grid">
           {% if data.compute_surfaces %}
               <button class="button1" onclick="openTab(event, '{{ data.fif_id }}_compute_surfaces', this.id)" style="border-top-style: solid">Surfaces</button>
@@ -14,7 +13,7 @@
           {% if data.coregister %}
               <button class="button1" onclick="openTab(event, '{{ data.fif_id }}_coregistration', this.id)" style="border-top-style: solid">Coregistration</button>
           {% endif %}
-          {% if data.beamform or data.beamform_and_parcellate%}
+          {% if data.beamform or data.beamform_and_parcellate %}
               <button class="button1" onclick="openTab(event, '{{ data.fif_id }}_beamforming', this.id)" style="border-top-style: solid">Beamforming</button>
           {% endif %}
           {% if data.beamform_and_parcellate or data.minimum_norm_and_parcellate %}
@@ -25,8 +24,9 @@
           {% endif %}
       </div>
     </div>
-  
-    <div class="flex-child" style="flex: 5; padding-left: 25px">
+
+    <div style="display: table-cell; width: 80%; padding-left: 25px; vertical-align: top">
+
   
       {% if data.compute_surfaces %}
           <div class="tabpage" style='width: 100%' id={{ data.fif_id }}_compute_surfaces>
@@ -84,7 +84,7 @@
       {% endif %}
   
       {% if data.coregister %}
-          <div class="tabpage" style='width: 100%' id={{ data.fif_id }}_coregistration>
+          <div class="tabpage" style='width: 100%; display: none' id={{ data.fif_id }}_coregistration>
               <h3>Coregistration
                   <span style="margin-right: 10px;"></span>
                   <button style="cursor: help; border: 1px solid; background-color: lightblue; color: black; padding: 2px 5px; font-size: 12px;" 
@@ -121,7 +121,7 @@
       {% endif %}
   
       {% if data.beamform_and_parcellate or data.minimum_norm_and_parcellate %}
-          <div class="tabpage" style='width: 100%; display: none' id={{ data.fif_id }}_parcellation>
+          <div class="tabpage" style="width: 100%; display: none" id={{ data.fif_id }}_parcellation>
               <h3>Parcellation</h3>
               <span style="margin-right: 10px;"></span>
               <button style="cursor: help; border: 1px solid; background-color: lightblue; color: black; padding: 2px 5px; font-size: 12px;" 
@@ -157,34 +157,363 @@
       </div>
     </div>
   </div>
-  
-  <script>
-  
-  function openTab(event, figTag, button) {
-      // Get all elements with class="tabpage" and hide them
-      tabpage = document.getElementsByClassName("tabpage");
-      for (i = 0; i < tabpage.length; i++) {
-          tabpage[i].style.display = "none";
-      }
-      // Show the current tab
-      document.getElementById(figTag).style.display = "block";
-      if (figTag.includes('compute_surfaces')) {
-          currentButton = 0;
-      }
-      if (figTag.includes('coregistration')) {
-          iframe = document.getElementById(figTag.concat('_iframe'));
-          iframe.src = iframe.getAttribute('data-src');
-          currentButton = 1;
-      }
-      if (figTag.includes('beamforming')) {
-          currentButton = 2;
-      }
-      if (figTag.includes('parcellation')) {
-          currentButton = 3;
-      }
-      if (figTag.includes('logs')) {
-          currentButton = 4;
-      }
+</div>
+
+<style>
+.button1.active {
+  background-color: lightgreen;
+  border-bottom: 2px solid #2e8b57;
+}
+</style>
+
+
+
+<script>
+(function () {
+  // initialize only once even if template rendered many times
+  if (window.__oslSrcPanelNavFixed__) return;
+  window.__oslSrcPanelNavFixed__ = true;
+
+  // Helper - find the currently visible .fif (first with offsetParent !== null)
+  function findVisibleFif() {
+    const all = Array.from(document.getElementsByClassName('fif'));
+    for (const el of all) {
+      if (el.offsetParent !== null) return el;
+    }
+    return all[0] || null;
   }
-  
-  </script>
+
+  // Helper - buttons inside a given fif (or the visible one)
+  function getButtonsForFif(fifEl) {
+    if (!fifEl) fifEl = findVisibleFif();
+    if (!fifEl) return [];
+    return Array.from(fifEl.querySelectorAll('.button1'));
+  }
+
+  // Parse figTag from inline onclick string (backwards compatibility)
+  function parseFigTagFromOnclick(onclickText) {
+    if (!onclickText) return null;
+    const m = onclickText.match(/openTab\([^,]*,\s*(['"])(.*?)\1/);
+    return m ? m[2] : null;
+  }
+
+  // Replacement openTab: operates *inside* the relevant .fif,
+  // sets .active on buttons, persists per-fif activeTab/currentIndex, lazy-loads iframe.
+  window.openTab = function (event, figTag, buttonId) {
+    if (!figTag) return;
+
+    // Find the .fif owning this tab (buttonId or figTag)
+    let fifEl = null;
+    if (buttonId) {
+      const byId = document.getElementById(buttonId);
+      if (byId) fifEl = byId.closest('.fif');
+    }
+    if (!fifEl) {
+      const tgt = document.getElementById(figTag);
+      if (tgt) fifEl = tgt.closest('.fif');
+    }
+    if (!fifEl) fifEl = findVisibleFif();
+
+    // Ensure visible fif is explicitly displayed as block to avoid layout reflow
+    if (fifEl) {
+      fifEl.style.display = 'block';
+      fifEl.style.boxSizing = 'border-box';
+      fifEl.style.width = '100%';
+    }
+
+    // Hide tabpages inside this .fif only
+    if (fifEl) {
+      const localPages = Array.from(fifEl.querySelectorAll('.tabpage'));
+      localPages.forEach(p => p.style.display = 'none');
+    } else {
+      // fallback global hide
+      const allPages = Array.from(document.getElementsByClassName('tabpage'));
+      allPages.forEach(p => p.style.display = 'none');
+    }
+
+    // Show the requested tabpage
+    const tgtEl = document.getElementById(figTag);
+    if (tgtEl) {
+      tgtEl.style.display = 'block';
+      // lazy-load iframe within this tab if present
+      const iframe = tgtEl.querySelector('iframe[data-src]');
+      if (iframe && iframe.getAttribute('data-src') && !iframe.src) {
+        iframe.src = iframe.getAttribute('data-src');
+      }
+    } else {
+      console.warn('openTab: target not found', figTag);
+    }
+
+    // Set .active within this .fif
+    const buttons = getButtonsForFif(fifEl);
+    buttons.forEach(b => b.classList.remove('active'));
+
+    // Determine index for the target (by buttonId, data-target, or inline onclick)
+    let idx = -1;
+    if (buttonId && buttons.length) {
+      idx = buttons.findIndex(b => b.id === buttonId);
+    }
+    if (idx === -1 && buttons.length) {
+      idx = buttons.findIndex(b => (b.dataset && b.dataset.target && b.dataset.target === figTag));
+      if (idx === -1) {
+        for (let i = 0; i < buttons.length; i++) {
+          const onclick = buttons[i].getAttribute('onclick') || '';
+          const tag = parseFigTagFromOnclick(onclick);
+          if (tag === figTag) { idx = i; break; }
+        }
+      }
+    }
+    if (idx === -1) idx = buttons.length > 0 ? 0 : -1;
+
+    if (idx !== -1 && buttons[idx]) {
+      buttons[idx].classList.add('active');
+      try { if (fifEl) fifEl.dataset.currentIndex = '' + idx; } catch (e) {}
+      try { if (fifEl) fifEl.dataset.activeTab = figTag; } catch (e) {}
+      try { buttons[idx].focus(); } catch (e) {}
+    }
+
+    // compatibility globals
+    try { window.currentFifId = fifEl ? (fifEl.id || null) : null; } catch (e) {}
+    try { window.currentButton = idx === -1 ? 0 : idx; } catch (e) {}
+  };
+
+  // Ensure clicks that call inline onclick still sync active class & persist dataset
+  function syncButtonClicks() {
+    const panels = Array.from(document.querySelectorAll('.fif'));
+    panels.forEach((fif) => {
+      const btns = Array.from(fif.querySelectorAll('.button1'));
+      btns.forEach((b) => {
+        if (b.__oslSyncBound) return;
+        b.addEventListener('click', function (ev) {
+          const parent = b.closest('.fif');
+          if (!parent) return;
+          const siblings = Array.from(parent.querySelectorAll('.button1'));
+          siblings.forEach(s => s.classList.remove('active'));
+          b.classList.add('active');
+          try { parent.dataset.currentIndex = '' + siblings.indexOf(b); } catch (e) {}
+          let target = b.dataset.target || parseFigTagFromOnclick(b.getAttribute('onclick') || '');
+          try { if (parent && target) parent.dataset.activeTab = target; } catch (e) {}
+        }, false);
+        b.__oslSyncBound = true;
+      });
+    });
+  }
+
+  // MutationObserver: when visible .fif changes, restore stored per-file tab and force display:block to avoid layout shifts
+  let lastVisibleId = null;
+  const mo = new MutationObserver(function () {
+    if (mo.__t) clearTimeout(mo.__t);
+    mo.__t = setTimeout(function () {
+      syncButtonClicks();
+      const vis = findVisibleFif();
+      const visId = vis ? vis.id : null;
+      if (vis && vis.style.display !== 'block') {
+        // explicitly set visible style to block to preserve layout
+        vis.style.display = 'block';
+        vis.style.boxSizing = 'border-box';
+        vis.style.width = '100%';
+      }
+      if (visId !== lastVisibleId) {
+        lastVisibleId = visId;
+        if (!vis) return;
+        const stored = vis.dataset && vis.dataset.activeTab ? vis.dataset.activeTab : null;
+        const buttons = Array.from(vis.querySelectorAll('.button1'));
+        if (stored) {
+          // find a button matching stored
+          let btn = buttons.find(b => (b.dataset && b.dataset.target && b.dataset.target === stored) || parseFigTagFromOnclick(b.getAttribute('onclick') || '') === stored);
+          if (btn) {
+            openTab(null, stored, btn.id);
+          } else if (buttons.length) {
+            const fallbackTarget = parseFigTagFromOnclick(buttons[0].getAttribute('onclick') || '');
+            if (fallbackTarget) openTab(null, fallbackTarget, buttons[0].id);
+          }
+        } else if (buttons.length) {
+          const fallbackTarget = parseFigTagFromOnclick(buttons[0].getAttribute('onclick') || '');
+          if (fallbackTarget) openTab(null, fallbackTarget, buttons[0].id);
+        }
+      }
+    }, 30);
+  });
+
+  mo.observe(document.body, { attributes: true, childList: true, subtree: true, attributeFilter: ['style', 'class'] });
+
+  // initial setup
+  document.addEventListener('DOMContentLoaded', function () {
+    syncButtonClicks();
+    // ensure visible panel is block and has an active tab open
+    const vis = findVisibleFif();
+    if (vis) {
+      vis.style.display = 'block';
+      vis.style.boxSizing = 'border-box';
+      vis.style.width = '100%';
+      const buttons = Array.from(vis.querySelectorAll('.button1'));
+      if (buttons.length) {
+        // if a button already has .active, use it; otherwise open the first
+        const active = buttons.find(b => b.classList.contains('active'));
+        if (active) {
+          const target = active.dataset.target || parseFigTagFromOnclick(active.getAttribute('onclick') || '');
+          if (target) openTab(null, target, active.id);
+        } else {
+          const target = parseFigTagFromOnclick(buttons[0].getAttribute('onclick') || '');
+          if (target) openTab(null, target, buttons[0].id);
+        }
+      }
+    }
+  });
+
+  // immediate-run if DOMContentLoaded already fired
+  if (document.readyState === 'interactive' || document.readyState === 'complete') {
+    syncButtonClicks();
+    const vis = findVisibleFif();
+    if (vis) {
+      vis.style.display = 'block';
+      vis.style.boxSizing = 'border-box';
+      vis.style.width = '100%';
+      const buttons = Array.from(vis.querySelectorAll('.button1'));
+      if (buttons.length) {
+        const active = buttons.find(b => b.classList.contains('active'));
+        if (active) {
+          const target = active.dataset.target || parseFigTagFromOnclick(active.getAttribute('onclick') || '');
+          if (target) openTab(null, target, active.id);
+        } else {
+          const target = parseFigTagFromOnclick(buttons[0].getAttribute('onclick') || '');
+          if (target) openTab(null, target, buttons[0].id);
+        }
+      }
+    }
+  }
+
+})();
+</script>
+
+
+<!-- BEGIN: osl-fif stacking fix -->
+<script>
+(function () {
+  if (window.__oslFifStacked__) return;
+  window.__oslFifStacked__ = true;
+
+  function createWrapperIfNeeded() {
+    // if already present, return it
+    const existing = document.getElementById('osl-fif-wrapper');
+    if (existing) return existing;
+
+    const all = Array.from(document.getElementsByClassName('fif'));
+    if (!all.length) return null;
+
+    const wrapper = document.createElement('div');
+    wrapper.id = 'osl-fif-wrapper';
+    // wrapper reserves space in the document flow; children are absolutely stacked inside it
+    wrapper.style.position = 'relative';
+    wrapper.style.width = '100%';
+    wrapper.style.boxSizing = 'border-box';
+
+    const first = all[0];
+    first.parentNode.insertBefore(wrapper, first);
+
+    // move all .fif nodes into the wrapper in order
+    all.forEach(el => wrapper.appendChild(el));
+    return wrapper;
+  }
+
+  function measureAndApply() {
+    const wrapper = createWrapperIfNeeded();
+    if (!wrapper) return;
+    const fifEls = Array.from(wrapper.getElementsByClassName('fif'));
+    if (!fifEls.length) return;
+
+    // stack them absolutely; visible one stays visible; others hidden
+    fifEls.forEach(el => {
+      el.style.position = 'absolute';
+      el.style.top = '0';
+      el.style.left = '0';
+      el.style.width = '100%';
+      el.style.boxSizing = 'border-box';
+      // do not change display here — we'll set it correctly below
+    });
+
+    // Ensure every panel is measurable: temporarily make hidden ones block+invisible
+    const changed = [];
+    fifEls.forEach(el => {
+      const cs = getComputedStyle(el);
+      if (cs.display === 'none') {
+        changed.push({ el, prevDisplay: el.style.display, prevVisibility: el.style.visibility });
+        el.style.display = 'block';
+        el.style.visibility = 'hidden';
+      }
+    });
+
+    // compute maximum natural height
+    let max = 0;
+    for (const el of fifEls) {
+      // use scrollHeight (works even if children overflow)
+      const h = Math.ceil(el.getBoundingClientRect().height || el.scrollHeight || 0);
+      if (h > max) max = h;
+    }
+
+    // restore temporaries
+    changed.forEach(obj => {
+      obj.el.style.display = obj.prevDisplay || 'none';
+      obj.el.style.visibility = obj.prevVisibility || '';
+    });
+
+    // ensure only the intended visible panel is display:block; others display:none
+    // find a currently visible one (offsetParent !== null) as best candidate
+    let vis = fifEls.find(e => e.offsetParent !== null);
+    if (!vis) {
+      // fallback: prefer one with dataset.activeTab or first
+      vis = fifEls.find(e => e.dataset && e.dataset.activeTab) || fifEls[0];
+    }
+    fifEls.forEach(el => {
+      if (el === vis) {
+        el.style.display = 'block';
+        el.style.visibility = '';
+      } else {
+        el.style.display = 'none';
+      }
+    });
+
+    if (max > 0) {
+      wrapper.style.minHeight = max + 'px';
+    } else {
+      // safety fallback
+      wrapper.style.minHeight = '';
+    }
+  }
+
+  // run measurement on DOM ready + load
+  document.addEventListener('DOMContentLoaded', function () {
+    // allow the rest of your init code to run first
+    setTimeout(measureAndApply, 30);
+  });
+  window.addEventListener('load', function () {
+    setTimeout(measureAndApply, 30);
+  });
+
+  // re-run when media loads (images / iframes inside .fif)
+  function attachMediaListeners() {
+    const media = Array.from(document.querySelectorAll('.fif img, .fif iframe'));
+    media.forEach(m => {
+      if (m.__oslFifBound__) return;
+      m.addEventListener('load', function () { setTimeout(measureAndApply, 40); }, { passive: true });
+      m.__oslFifBound__ = true;
+    });
+  }
+  document.addEventListener('DOMContentLoaded', attachMediaListeners);
+  window.addEventListener('load', attachMediaListeners);
+
+  // watch for DOM changes that might change which .fif is visible
+  const mo = new MutationObserver(function () {
+    if (mo.__t) clearTimeout(mo.__t);
+    mo.__t = setTimeout(function () {
+      attachMediaListeners();
+      measureAndApply();
+    }, 40);
+  });
+  mo.observe(document.body, { attributes: true, childList: true, subtree: true, attributeFilter: ['style', 'class'] });
+
+  // expose for debugging if needed
+  window.__oslMeasureFifPanels = measureAndApply;
+})();
+</script>
+<!-- END: osl-fif stacking fix -->

--- a/osl_ephys/report/templates/src_summary_panel.html
+++ b/osl_ephys/report/templates/src_summary_panel.html
@@ -3,22 +3,34 @@
   
     <div class="flex-child" style="flex: 1">
       <div class="tab" style="display: grid">
-          <button class="button1" onclick="openTab(event, 'config', this.id)" style="border-top-style: solid">Config</button>
-          {% if data.coregister %}
-              <button class="button1" onclick="openTab(event, 'coregistration', this.id)" style="border-top-style: solid">Coregistration</button>
-          {% endif %}
-          {% if data.beamform_and_parcellate %}
-              <button class="button1" onclick="openTab(event, 'parcellation', this.id)" style="border-top-style: solid">Parcellation</button>
-          {% endif %}
-          {% if data.fix_sign_ambiguity %}
-              <button class="button1" onclick="openTab(event, 'sign_flipping', this.id)" style="border-top-style: solid">Sign Flipping</button>
-          {% endif %}
-          {% if data.batchlog is defined %}
-              <button class="button1" onclick="openTab(event, 'batchlog', this.id)" style="border-top-style: solid">Batch Log</button>
-          {% endif %}
-          {% if data.errlog is defined %}
-              <button class="button1" onclick="openTab(event, 'errlog', this.id)" style="border-top-style: solid">Error Logs</button>
-          {% endif %}
+        <button class="button1" id="btn_config"
+                onclick="openTab(event, 'config', this.id)" style="border-top-style: solid">Config</button>
+
+        {% if data.coregister %}
+        <button class="button1" id="btn_coregistration"
+                onclick="openTab(event, 'coregistration', this.id)" style="border-top-style: solid">Coregistration</button>
+        {% endif %}
+
+        {% if data.beamform_and_parcellate %}
+        <button class="button1" id="btn_parcellation"
+                onclick="openTab(event, 'parcellation', this.id)" style="border-top-style: solid">Parcellation</button>
+        {% endif %}
+
+        {% if data.fix_sign_ambiguity %}
+        <button class="button1" id="btn_sign_flipping"
+                onclick="openTab(event, 'sign_flipping', this.id)" style="border-top-style: solid">Sign Flipping</button>
+        {% endif %}
+
+        {% if data.batchlog is defined %}
+        <button class="button1" id="btn_batchlog"
+                onclick="openTab(event, 'batchlog', this.id)" style="border-top-style: solid">Batch Log</button>
+        {% endif %}
+
+        {% if data.errlog is defined %}
+        <button class="button1" id="btn_errlog"
+                onclick="openTab(event, 'errlog', this.id)" style="border-top-style: solid">Error Logs</button>
+        {% endif %}
+
       </div>
     </div>
   
@@ -116,34 +128,6 @@
   
   <script>
   
-  function openTab(event, figTag, button) {
-      // Get all elements with class="tabpage" and hide them
-      tabpage = document.getElementsByClassName("tabpage");
-      for (i = 0; i < tabpage.length; i++) {
-          tabpage[i].style.display = "none";
-      }
-      // Show the current tab
-      document.getElementById(figTag).style.display = "block";
-      if (figTag.includes('config')) {
-          currentButton = 0;
-      }
-      if (figTag.includes('coregistration')) {
-          currentButton = 1;
-      }
-      if (figTag.includes('parcellation')) {
-          currentButton = 2;
-      }
-      if (figTag.includes('sign_flipping')) {
-          currentButton = 3;
-      }
-      if (figTag.includes('batchlog')) {
-          currentButton = 4;
-      }
-      if (figTag.includes('errlog')) {
-          currentButton = 5;
-      }
-  }
-  
   document.addEventListener('DOMContentLoaded', function() {
       $('#coreg_tbl').DataTable();
     });
@@ -156,3 +140,48 @@
   <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.24/css/jquery.dataTables.css">
   <script type="text/javascript" charset="utf8" src="https://code.jquery.com/jquery-3.5.1.js"></script>
   <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.24/js/jquery.dataTables.js"></script>
+
+<style>
+.button1.active {
+  background-color: lightgreen;
+  border-bottom: 2px solid #2e8b57;
+}
+</style>
+
+<script>
+function openTab(event, figTag, buttonId) {
+    const tabpages = document.getElementsByClassName("tabpage");
+    for (let i = 0; i < tabpages.length; i++) {
+        tabpages[i].style.display = "none";
+    }
+
+    const tgt = document.getElementById(figTag);
+    if (tgt) tgt.style.display = "block";
+
+    const buttons = document.querySelectorAll('.tab .button1');
+    buttons.forEach(b => b.classList.remove('active'));
+
+    if (buttonId) {
+        const activeBtn = document.getElementById(buttonId);
+        if (activeBtn) activeBtn.classList.add('active');
+    }
+}
+
+document.addEventListener('keydown', function (e) {
+    if (['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName) || document.activeElement.isContentEditable) return;
+
+    const buttons = Array.from(document.querySelectorAll('.tab .button1'));
+    if (!buttons.length) return;
+
+    const currentIndex = buttons.findIndex(b => b.classList.contains('active'));
+    if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        const next = (currentIndex + 1) % buttons.length;
+        buttons[next].click();
+    } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        const prev = (currentIndex - 1 + buttons.length) % buttons.length;
+        buttons[prev].click();
+    }
+});
+</script>

--- a/osl_ephys/report/templates/subject_report.html
+++ b/osl_ephys/report/templates/subject_report.html
@@ -42,7 +42,8 @@
           <br><br>
         </form>
         <div style='max-width: 70%; margin: auto; padding: 0px 25px 20px 25px;'>
-            The panels below summarise each fif file (full list on the right). Use arrow keys to navigate tabs.
+            The panels below summarise each fif file (full list on the right). Use arrow keys to navigate tabs.<br>
+            If you hover over the question mark buttons, you will see guidance about what to look for in each plot.
         </div>
     </div>
     <div style='width: 80%; margin: auto; text-align: center; float: left'>

--- a/osl_ephys/report/templates/subject_report.html
+++ b/osl_ephys/report/templates/subject_report.html
@@ -46,12 +46,12 @@
             If you hover over the question mark buttons, you will see guidance about what to look for in each plot.
         </div>
     </div>
-    <div style='width: 80%; margin: auto; text-align: center; float: left'>
+    <div style='width: 85%; text-align: center; float: left'>
         {% for panel in panels %}
             {{ panel }}
         {% endfor %}
     </div>
-    <div style="width: 20%; text-align: left; float: right">
+    <div style="width: 15%; text-align: left; float: right">
         <div>
             {{ filenames }}
         </div>

--- a/osl_ephys/report/templates/summary_report.html
+++ b/osl_ephys/report/templates/summary_report.html
@@ -31,6 +31,9 @@
 
 <div style='width:100%; margin: auto; text-align: center' >
     <h2>OSL Report: Summary</h2>
+        <div style='max-width: 70%; margin: auto; padding: 0px 25px 20px 25px;'>
+            If you hover over the question mark buttons, you will see guidance about what to look for in each plot.
+        </div>
 </div>
 
 <div class="float-container">


### PR DESCRIPTION
- Improved detection of maxfilter zeroes when no maxfilter log files are available
- Added automatic creation of custom tabs to the preproc and summary reports if figures are created in custom functions*
- Fixed the power topo plots in the subject report.
- Highlight the current active tap in subject/summary preproc report
- fix preproc report navigation

\* This works as follows:
if adding a custom function, figures are automatically saved as .png files in either the subject's folder, or the general output folder:

```
def subject_psd(dataset, userargs):
    dataset['fig']['Subject PSD'] = dataset['raw'].compute_psd().plot()
    return dataset

def group_psd(dataset, userargs):
    fig = plt.figure()
    psd = []
    for r in dataset['raw']:
        tmp = mne.io.read_raw(r).compute_psd(picks='meg', fmin=1, fmax=30)
        f = tmp.freqs
        psd.append(np.mean(tmp.get_data(), axis=0))
    psd = np.array(psd)
    plt.plot(f, psd.T)
    dataset['fig']['Group PSD'] = fig
    return dataset

config = """
    preproc: 
        - subject_psd: {}
    group:
        - group_psd: {}
"""

```

Here, the subject report will have a tab called "Subject PSD" (i.e., the key-name in `dataset['fig']`), and likewise the summary report will have a tab called "Group PSD" with the respective figures