### PR TITLE
Fix for volumetric minimum norm inverse solution.

### DIFF
--- a/osl_ephys/source_recon/minimum_norm.py
+++ b/osl_ephys/source_recon/minimum_norm.py
@@ -279,7 +279,7 @@ def apply_inverse_operator_vol(
         data,
         inverse_operator,
         lambda2=lambda2,
-        pick_ori=pick_ori,
+        pick_ori="vector",
         method=method,
         method_params={"eps": 1e-8, "max_iter": 100},
     )


### PR DESCRIPTION
We use `PCA` to project the 3D source time series onto a one-dimensional orientation, but we should not pass `pick_ori="pca"`. In MNE-Python, `pick_ori="vector"` returns the three-component vector time series, and the PCA projection is performed separately by us.